### PR TITLE
Implement WBAB lint/check/test in CI/CD and enable v0.0.1 release

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,17 @@ jobs:
         shell: bash
         run: ./tools/wbab preflight
         
+      - name: WBAB Lint
+        shell: bash
+        run: ./tools/wbab lint
+
       - name: WBAB Build
         shell: bash
         run: ./tools/wbab build ${GITHUB_REF_NAME}
+
+      - name: WBAB Test
+        shell: bash
+        run: ./tools/wbab test
         
       - name: WBAB Package
         shell: bash

--- a/clients/cli/src/cli.cpp
+++ b/clients/cli/src/cli.cpp
@@ -1,120 +1,141 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
 #include <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
-#include <string>
-#include <iostream>
-#include <sstream>
-#include <vector>
 
-#include "wininspect/tinyjson.hpp"
 #include "wininspect/core.hpp"
+#include "wininspect/tinyjson.hpp"
 
-#include <fstream>
 #include <filesystem>
+#include <fstream>
 
 #include "wininspect/crypto.hpp"
 
 #pragma comment(lib, "Ws2_32.lib")
 #pragma comment(lib, "Advapi32.lib") // For CryptGenRandom
 
-static const wchar_t* PIPE_NAME = L"\\\\.\\pipe\\wininspectd";
+static const wchar_t *PIPE_NAME = L"\\\\.\\pipe\\wininspectd";
 
 static std::string get_config_path() {
-    const char* home = getenv("USERPROFILE");
-    if (!home) home = getenv("HOME");
-    if (!home) return ".wininspect_config";
-    return std::string(home) + "/.wininspect_config";
+  const char *home = getenv("USERPROFILE");
+  if (!home)
+    home = getenv("HOME");
+  if (!home)
+    return ".wininspect_config";
+  return std::string(home) + "/.wininspect_config";
 }
 
-static void save_key_path(const std::string& path) {
-    std::ofstream f(get_config_path());
-    f << path;
+static void save_key_path(const std::string &path) {
+  std::ofstream f(get_config_path());
+  f << path;
 }
 
 static std::string load_key_path() {
-    std::ifstream f(get_config_path());
-    std::string s;
-    std::getline(f, s);
-    return s;
+  std::ifstream f(get_config_path());
+  std::string s;
+  std::getline(f, s);
+  return s;
 }
 
-static std::vector<uint8_t> base64_decode(const std::string& in) {
-    static const std::string b64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    std::vector<uint8_t> out;
-    std::vector<int> T(256, -1);
-    for (int i = 0; i < 64; i++) T[b64[i]] = i;
-    int val = 0, valb = -8;
-    for (char c : in) {
-        if (T[c] == -1) break;
-        val = (val << 6) + T[c];
-        valb += 6;
-        if (valb >= 0) {
-            out.push_back(uint8_t((val >> valb) & 0xFF));
-            valb -= 8;
-        }
+static std::vector<uint8_t> base64_decode(const std::string &in) {
+  static const std::string b64 =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  std::vector<uint8_t> out;
+  std::vector<int> T(256, -1);
+  for (int i = 0; i < 64; i++)
+    T[b64[i]] = i;
+  int val = 0, valb = -8;
+  for (char c : in) {
+    if (T[c] == -1)
+      break;
+    val = (val << 6) + T[c];
+    valb += 6;
+    if (valb >= 0) {
+      out.push_back(uint8_t((val >> valb) & 0xFF));
+      valb -= 8;
     }
-    return out;
+  }
+  return out;
 }
 
-static bool perform_auth(Conn& conn) {
-    std::string challenge_json;
-    if (!conn.recv(challenge_json)) return false;
-    auto v = wininspect::json::parse(challenge_json);
-    if (!v.is_obj() || v.as_obj().at("type").as_str() != "hello") return true; // No auth required (or old daemon)
+static bool perform_auth(Conn &conn) {
+  std::string challenge_json;
+  if (!conn.recv(challenge_json))
+    return false;
+  auto v = wininspect::json::parse(challenge_json);
+  if (!v.is_obj() || v.as_obj().at("type").as_str() != "hello")
+    return true; // No auth required (or old daemon)
 
-    std::string nonce_b64 = v.as_obj().at("nonce").as_str();
-    std::string key_path = load_key_path();
-    if (key_path.empty()) {
-        std::cerr << "Daemon requires authentication. Set key with: wininspect config --key <path>\n";
-        return false;
-    }
+  std::string nonce_b64 = v.as_obj().at("nonce").as_str();
+  std::string key_path = load_key_path();
+  if (key_path.empty()) {
+    std::cerr << "Daemon requires authentication. Set key with: wininspect "
+                 "config --key <path>\n";
+    return false;
+  }
 
-    std::string sig = wininspect::crypto::sign_ssh_msg(base64_decode(nonce_b64), key_path);
-    if (sig.empty()) {
-        std::cerr << "Failed to sign challenge with key: " << key_path << "\n";
-        return false;
-    }
+  std::string sig =
+      wininspect::crypto::sign_ssh_msg(base64_decode(nonce_b64), key_path);
+  if (sig.empty()) {
+    std::cerr << "Failed to sign challenge with key: " << key_path << "\n";
+    return false;
+  }
 
-    wininspect::json::Object resp;
-    resp["version"] = std::string(wininspect::PROTOCOL_VERSION);
-    resp["identity"] = "wininspect-user";
-    resp["signature"] = sig;
-    if (!conn.send(wininspect::json::dumps(resp))) return false;
+  wininspect::json::Object resp;
+  resp["version"] = std::string(wininspect::PROTOCOL_VERSION);
+  resp["identity"] = "wininspect-user";
+  resp["signature"] = sig;
+  if (!conn.send(wininspect::json::dumps(resp)))
+    return false;
 
-    std::string status_json;
-    if (!conn.recv(status_json)) return false;
-    auto sv = wininspect::json::parse(status_json);
-    return sv.is_obj() && sv.as_obj().at("type").as_str() == "auth_status" && sv.as_obj().at("ok").as_bool();
+  std::string status_json;
+  if (!conn.recv(status_json))
+    return false;
+  auto sv = wininspect::json::parse(status_json);
+  return sv.is_obj() && sv.as_obj().at("type").as_str() == "auth_status" &&
+         sv.as_obj().at("ok").as_bool();
 }
 
-static bool connect_daemon(Conn& conn, bool tcp, const std::string& host, int port) {
-    if (tcp) {
-        WSADATA wsa;
-        if (WSAStartup(MAKEWORD(2,2), &wsa) != 0) return false;
-        conn.s = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-        if (conn.s == INVALID_SOCKET) return false;
-        sockaddr_in addr{};
-        addr.sin_family = AF_INET;
-        addr.sin_port = htons((u_short)port);
-        inet_pton(AF_INET, host.c_str(), &addr.sin_addr);
-        if (connect(conn.s, (sockaddr*)&addr, sizeof(addr)) == SOCKET_ERROR) {
-            closesocket(conn.s);
-            return false;
-        }
-        conn.is_tcp = true;
-        if (!perform_auth(conn)) { conn.close(); return false; }
-        return true;
-    } else {
-        conn.hPipe = CreateFileW(PIPE_NAME, GENERIC_READ|GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
-        if (conn.hPipe == INVALID_HANDLE_VALUE) return false;
-        conn.is_tcp = false;
-        return true;
+static bool connect_daemon(Conn &conn, bool tcp, const std::string &host,
+                           int port) {
+  if (tcp) {
+    WSADATA wsa;
+    if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0)
+      return false;
+    conn.s = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (conn.s == INVALID_SOCKET)
+      return false;
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons((u_short)port);
+    inet_pton(AF_INET, host.c_str(), &addr.sin_addr);
+    if (connect(conn.s, (sockaddr *)&addr, sizeof(addr)) == SOCKET_ERROR) {
+      closesocket(conn.s);
+      return false;
     }
+    conn.is_tcp = true;
+    if (!perform_auth(conn)) {
+      conn.close();
+      return false;
+    }
+    return true;
+  } else {
+    conn.hPipe = CreateFileW(PIPE_NAME, GENERIC_READ | GENERIC_WRITE, 0,
+                             nullptr, OPEN_EXISTING, 0, nullptr);
+    if (conn.hPipe == INVALID_HANDLE_VALUE)
+      return false;
+    conn.is_tcp = false;
+    return true;
+  }
 }
 
-static std::string make_req(const std::string& id, const std::string& method, wininspect::json::Object params) {
+static std::string make_req(const std::string &id, const std::string &method,
+                            wininspect::json::Object params) {
   using namespace wininspect::json;
   Object o;
   o["id"] = id;
@@ -144,65 +165,67 @@ static int usage() {
   return 2;
 }
 
-int main(int argc, char** argv) {
-  if (argc < 2) return usage();
-  
+int main(int argc, char **argv) {
+  if (argc < 2)
+    return usage();
+
   bool use_tcp = false;
   std::string tcp_host = "127.0.0.1";
   int tcp_port = 1985;
 
   std::vector<std::string> args;
   for (int i = 1; i < argc; ++i) {
-      if (std::string(argv[i]) == "--tcp") {
-          use_tcp = true;
-          if (i + 1 < argc) {
-              std::string host_port = argv[i+1];
-              size_t colon = host_port.find(':');
-              if (colon != std::string::npos) {
-                  tcp_host = host_port.substr(0, colon);
-                  tcp_port = std::stoi(host_port.substr(colon + 1));
-              } else {
-                  tcp_host = host_port;
-              }
-              i++;
-          }
-      } else {
-          args.push_back(argv[i]);
+    if (std::string(argv[i]) == "--tcp") {
+      use_tcp = true;
+      if (i + 1 < argc) {
+        std::string host_port = argv[i + 1];
+        size_t colon = host_port.find(':');
+        if (colon != std::string::npos) {
+          tcp_host = host_port.substr(0, colon);
+          tcp_port = std::stoi(host_port.substr(colon + 1));
+        } else {
+          tcp_host = host_port;
+        }
+        i++;
       }
+    } else {
+      args.push_back(argv[i]);
+    }
   }
 
-  if (args.empty()) return usage();
+  if (args.empty())
+    return usage();
   std::string cmd = args[0];
 
   using namespace wininspect::json;
   Object params;
   params["canonical"] = true;
 
-  auto get_snapshot = [&](size_t& i) {
-    if (i+1 < args.size() && args[i] == "--snapshot") {
-      params["snapshot_id"] = args[i+1];
+  auto get_snapshot = [&](size_t &i) {
+    if (i + 1 < args.size() && args[i] == "--snapshot") {
+      params["snapshot_id"] = args[i + 1];
       i += 2;
       return true;
     }
     return false;
   };
 
-  auto send_and_print = [&](const std::string& method) {
-      Conn conn;
-      if (!connect_daemon(conn, use_tcp, tcp_host, tcp_port)) {
-          std::cerr << "failed to connect to daemon\n";
-          return 1;
-      }
-      std::string req = make_req("cli-1", method, params);
-      std::string resp;
-      if (!conn.send(req) || !conn.recv(resp)) {
-          std::cerr << "communication error\n";
-          conn.close();
-          return 1;
-      }
-      std::cout << resp << "\n";
+  auto send_and_print = [&](const std::string &method) {
+    Conn conn;
+    if (!connect_daemon(conn, use_tcp, tcp_host, tcp_port)) {
+      std::cerr << "failed to connect to daemon\n";
+      return 1;
+    }
+    std::string req = make_req("cli-1", method, params);
+    std::string resp;
+    if (!conn.send(req) || !conn.recv(resp)) {
+      std::cerr << "communication error\n";
       conn.close();
-      return 0;
+      return 1;
+    }
+    std::cout << resp << "\n";
+    conn.close();
+    return 0;
   };
 
   if (cmd == "capture") {
@@ -210,111 +233,131 @@ int main(int argc, char** argv) {
   }
 
   if (cmd == "top") {
-    for (size_t i = 1; i < args.size();) if (!get_snapshot(i)) i++;
+    for (size_t i = 1; i < args.size();)
+      if (!get_snapshot(i))
+        i++;
     return send_and_print("window.listTop");
   }
 
   if (cmd == "info") {
-    if (args.size() < 2) return usage();
+    if (args.size() < 2)
+      return usage();
     params["hwnd"] = args[1];
-    for (size_t i = 2; i < args.size();) if (!get_snapshot(i)) i++;
+    for (size_t i = 2; i < args.size();)
+      if (!get_snapshot(i))
+        i++;
     return send_and_print("window.getInfo");
   }
 
   if (cmd == "children") {
-    if (args.size() < 2) return usage();
+    if (args.size() < 2)
+      return usage();
     params["hwnd"] = args[1];
-    for (size_t i = 2; i < args.size();) if (!get_snapshot(i)) i++;
+    for (size_t i = 2; i < args.size();)
+      if (!get_snapshot(i))
+        i++;
     return send_and_print("window.listChildren");
   }
 
   if (cmd == "pick") {
-      if (args.size() < 3) return usage();
-      params["x"] = std::stod(args[1]);
-      params["y"] = std::stod(args[2]);
-      for (size_t i = 3; i < args.size();) if (!get_snapshot(i)) i++;
-      return send_and_print("window.pickAtPoint");
+    if (args.size() < 3)
+      return usage();
+    params["x"] = std::stod(args[1]);
+    params["y"] = std::stod(args[2]);
+    for (size_t i = 3; i < args.size();)
+      if (!get_snapshot(i))
+        i++;
+    return send_and_print("window.pickAtPoint");
   }
 
   if (cmd == "events-poll") {
-      if (args.size() < 2) return usage();
-      params["snapshot_id"] = args[1];
-      if (args.size() > 2) params["old_snapshot_id"] = args[2];
-      return send_and_print("events.poll");
+    if (args.size() < 2)
+      return usage();
+    params["snapshot_id"] = args[1];
+    if (args.size() > 2)
+      params["old_snapshot_id"] = args[2];
+    return send_and_print("events.poll");
   }
 
   if (cmd == "events-subscribe") {
-      return send_and_print("events.subscribe");
+    return send_and_print("events.subscribe");
   }
 
   if (cmd == "events-unsubscribe") {
-      return send_and_print("events.unsubscribe");
+    return send_and_print("events.unsubscribe");
   }
 
   if (cmd == "watch") {
-      Conn conn;
-      if (!connect_daemon(conn, use_tcp, tcp_host, tcp_port)) return 1;
-      
-      std::string resp;
-      std::cout << "Watching for window events... (Ctrl+C to stop)\n";
-      
-      // Initialize baseline snapshot
-      conn.send(make_req("w-0", "events.poll", params));
-      conn.recv(resp);
+    Conn conn;
+    if (!connect_daemon(conn, use_tcp, tcp_host, tcp_port))
+      return 1;
 
-      while (true) {
-          Sleep(1000);
-          conn.send(make_req("w-1", "events.poll", params));
-          if (conn.recv(resp)) {
-              std::cout << resp << "\n";
-          }
+    std::string resp;
+    std::cout << "Watching for window events... (Ctrl+C to stop)\n";
+
+    // Initialize baseline snapshot
+    conn.send(make_req("w-0", "events.poll", params));
+    conn.recv(resp);
+
+    while (true) {
+      Sleep(1000);
+      conn.send(make_req("w-1", "events.poll", params));
+      if (conn.recv(resp)) {
+        std::cout << resp << "\n";
       }
-      return 0;
+    }
+    return 0;
   }
 
   if (cmd == "status") {
-      return send_and_print("daemon.status");
+    return send_and_print("daemon.status");
   }
 
   if (cmd == "ensure-visible") {
-      if (args.size() < 3) return usage();
-      params["hwnd"] = args[1];
-      params["visible"] = (args[2] == "true");
-      return send_and_print("window.ensureVisible");
+    if (args.size() < 3)
+      return usage();
+    params["hwnd"] = args[1];
+    params["visible"] = (args[2] == "true");
+    return send_and_print("window.ensureVisible");
   }
 
   if (cmd == "ensure-foreground") {
-      if (args.size() < 2) return usage();
-      params["hwnd"] = args[1];
-      return send_and_print("window.ensureForeground");
+    if (args.size() < 2)
+      return usage();
+    params["hwnd"] = args[1];
+    return send_and_print("window.ensureForeground");
   }
 
   if (cmd == "post-message") {
-      if (args.size() < 3) return usage();
-      params["hwnd"] = args[1];
-      params["msg"] = std::stod(args[2]);
-      if (args.size() > 3) params["wparam"] = std::stod(args[3]);
-      if (args.size() > 4) params["lparam"] = std::stod(args[4]);
-      return send_and_print("window.postMessage");
+    if (args.size() < 3)
+      return usage();
+    params["hwnd"] = args[1];
+    params["msg"] = std::stod(args[2]);
+    if (args.size() > 3)
+      params["wparam"] = std::stod(args[3]);
+    if (args.size() > 4)
+      params["lparam"] = std::stod(args[4]);
+    return send_and_print("window.postMessage");
   }
 
   if (cmd == "send-input") {
-      if (args.size() < 2) return usage();
-      params["data_b64"] = args[1];
-      return send_and_print("input.send");
+    if (args.size() < 2)
+      return usage();
+    params["data_b64"] = args[1];
+    return send_and_print("input.send");
   }
 
   if (cmd == "config") {
-      if (args.size() >= 3 && args[1] == "--key") {
-          save_key_path(args[2]);
-          std::cout << "Key path saved: " << args[2] << "\n";
-          return 0;
-      }
-      return usage();
+    if (args.size() >= 3 && args[1] == "--key") {
+      save_key_path(args[2]);
+      std::cout << "Key path saved: " << args[2] << "\n";
+      return 0;
+    }
+    return usage();
   }
 
   return usage();
 }
 #else
-int main(){return 0;}
+int main() { return 0; }
 #endif

--- a/clients/gui/src/gui_main.cpp
+++ b/clients/gui/src/gui_main.cpp
@@ -1,10 +1,10 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
 #include <commctrl.h>
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
+#include <windows.h>
 
 #include "viewmodel.hpp"
 #include "wininspect/tinyjson.hpp"
@@ -16,186 +16,207 @@ using namespace wininspect_gui;
 // Simple pipe transport for the GUI
 class PipeTransport : public ITransport {
 public:
-    std::string request(const std::string& json) override {
-        HANDLE h = CreateFileW(L"\.\pipe\wininspectd", GENERIC_READ|GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
-        if (h == INVALID_HANDLE_VALUE) return "{"ok":false,"error":"no daemon"}";
-        
-        uint32_t len = (uint32_t)json.size();
-        DWORD w = 0;
-        WriteFile(h, &len, 4, &w, nullptr);
-        WriteFile(h, json.data(), len, &w, nullptr);
+  std::string request(const std::string &json) override {
+    HANDLE h = CreateFileW(L"\.\pipe\wininspectd", GENERIC_READ | GENERIC_WRITE,
+                           0, nullptr, OPEN_EXISTING, 0, nullptr);
+    if (h == INVALID_HANDLE_VALUE)
+      return "{" ok ":false," error ":" no daemon "}";
 
-        uint32_t rlen = 0;
-        DWORD r = 0;
-        if (!ReadFile(h, &rlen, 4, &r, nullptr)) { CloseHandle(h); return "{"ok":false}"; }
-        std::string resp; resp.resize(rlen);
-        ReadFile(h, resp.data(), rlen, &r, nullptr);
-        CloseHandle(h);
-        return resp;
+    uint32_t len = (uint32_t)json.size();
+    DWORD w = 0;
+    WriteFile(h, &len, 4, &w, nullptr);
+    WriteFile(h, json.data(), len, &w, nullptr);
+
+    uint32_t rlen = 0;
+    DWORD r = 0;
+    if (!ReadFile(h, &rlen, 4, &r, nullptr)) {
+      CloseHandle(h);
+      return "{" ok ":false}";
     }
+    std::string resp;
+    resp.resize(rlen);
+    ReadFile(h, resp.data(), rlen, &r, nullptr);
+    CloseHandle(h);
+    return resp;
+  }
 };
 
 class WinInspectWindow {
 public:
-    bool init(HINSTANCE hInst) {
-        hInst_ = hInst;
-        WNDCLASSEXW wc = { sizeof(WNDCLASSEXW) };
-        wc.lpfnWndProc = wndProc;
-        wc.hInstance = hInst_;
-        wc.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
-        wc.lpszClassName = L"WinInspectGUI";
-        wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
+  bool init(HINSTANCE hInst) {
+    hInst_ = hInst;
+    WNDCLASSEXW wc = {sizeof(WNDCLASSEXW)};
+    wc.lpfnWndProc = wndProc;
+    wc.hInstance = hInst_;
+    wc.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+    wc.lpszClassName = L"WinInspectGUI";
+    wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
 
-        if (!RegisterClassExW(&wc)) return false;
+    if (!RegisterClassExW(&wc))
+      return false;
 
-        hwnd_ = CreateWindowExW(0, wc.lpszClassName, L"WinInspect", WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, 800, 600, nullptr, nullptr, hInst_, this);
-        if (!hwnd_) return false;
+    hwnd_ = CreateWindowExW(0, wc.lpszClassName, L"WinInspect",
+                            WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT,
+                            800, 600, nullptr, nullptr, hInst_, this);
+    if (!hwnd_)
+      return false;
 
-        transport_ = std::make_unique<PipeTransport>();
-        vm_ = std::make_unique<ViewModel>(transport_.get());
+    transport_ = std::make_unique<PipeTransport>();
+    vm_ = std::make_unique<ViewModel>(transport_.get());
 
-        createControls();
-        refresh();
+    createControls();
+    refresh();
 
-        return true;
-    }
+    return true;
+  }
 
-    void show(int nCmdShow) {
-        ShowWindow(hwnd_, nCmdShow);
-        UpdateWindow(hwnd_);
-    }
+  void show(int nCmdShow) {
+    ShowWindow(hwnd_, nCmdShow);
+    UpdateWindow(hwnd_);
+  }
 
 private:
-    static LRESULT CALLBACK wndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
-        WinInspectWindow* self = nullptr;
-        if (uMsg == WM_NCCREATE) {
-            CREATESTRUCT* cs = (CREATESTRUCT*)lParam;
-            self = (WinInspectWindow*)cs->lpCreateParams;
-            SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)self);
-        } else {
-            self = (WinInspectWindow*)GetWindowLongPtr(hwnd, GWLP_USERDATA);
-        }
-
-        if (self) {
-            switch (uMsg) {
-                case WM_SIZE:
-                    self->onSize();
-                    return 0;
-                case WM_NOTIFY:
-                    self->onNotify(lParam);
-                    return 0;
-                case WM_DESTROY:
-                    PostQuitMessage(0);
-                    return 0;
-            }
-        }
-        return DefWindowProcW(hwnd, uMsg, wParam, lParam);
+  static LRESULT CALLBACK wndProc(HWND hwnd, UINT uMsg, WPARAM wParam,
+                                  LPARAM lParam) {
+    WinInspectWindow *self = nullptr;
+    if (uMsg == WM_NCCREATE) {
+      CREATESTRUCT *cs = (CREATESTRUCT *)lParam;
+      self = (WinInspectWindow *)cs->lpCreateParams;
+      SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)self);
+    } else {
+      self = (WinInspectWindow *)GetWindowLongPtr(hwnd, GWLP_USERDATA);
     }
 
-    void createControls() {
-        hTree_ = CreateWindowExW(0, WC_TREEVIEWW, L"", WS_VISIBLE | WS_CHILD | WS_BORDER | TVS_HASBUTTONS | TVS_LINESATROOT | TVS_HASLINES, 0, 0, 200, 600, hwnd_, (HMENU)101, hInst_, nullptr);
-        hList_ = CreateWindowExW(0, WC_LISTVIEWW, L"", WS_VISIBLE | WS_CHILD | WS_BORDER | LVS_REPORT, 200, 0, 600, 600, hwnd_, (HMENU)102, hInst_, nullptr);
-
-        ListView_SetExtendedListViewStyle(hList_, LVS_EX_FULLROWSELECT | LVS_EX_GRIDLINES);
-        
-        LVCOLUMNW col = { 0 };
-        col.mask = LVCF_TEXT | LVCF_WIDTH;
-        col.cx = 150;
-        col.pszText = (LPWSTR)L"Property";
-        ListView_InsertColumn(hList_, 0, &col);
-        col.cx = 400;
-        col.pszText = (LPWSTR)L"Value";
-        ListView_InsertColumn(hList_, 1, &col);
+    if (self) {
+      switch (uMsg) {
+      case WM_SIZE:
+        self->onSize();
+        return 0;
+      case WM_NOTIFY:
+        self->onNotify(lParam);
+        return 0;
+      case WM_DESTROY:
+        PostQuitMessage(0);
+        return 0;
+      }
     }
+    return DefWindowProcW(hwnd, uMsg, wParam, lParam);
+  }
 
-    void onSize() {
-        RECT r;
-        GetClientRect(hwnd_, &r);
-        int w = r.right - r.left;
-        int h = r.bottom - r.top;
-        int split = 250;
-        MoveWindow(hTree_, 0, 0, split, h, TRUE);
-        MoveWindow(hList_, split, 0, w - split, h, TRUE);
+  void createControls() {
+    hTree_ =
+        CreateWindowExW(0, WC_TREEVIEWW, L"",
+                        WS_VISIBLE | WS_CHILD | WS_BORDER | TVS_HASBUTTONS |
+                            TVS_LINESATROOT | TVS_HASLINES,
+                        0, 0, 200, 600, hwnd_, (HMENU)101, hInst_, nullptr);
+    hList_ = CreateWindowExW(
+        0, WC_LISTVIEWW, L"", WS_VISIBLE | WS_CHILD | WS_BORDER | LVS_REPORT,
+        200, 0, 600, 600, hwnd_, (HMENU)102, hInst_, nullptr);
+
+    ListView_SetExtendedListViewStyle(hList_,
+                                      LVS_EX_FULLROWSELECT | LVS_EX_GRIDLINES);
+
+    LVCOLUMNW col = {0};
+    col.mask = LVCF_TEXT | LVCF_WIDTH;
+    col.cx = 150;
+    col.pszText = (LPWSTR)L"Property";
+    ListView_InsertColumn(hList_, 0, &col);
+    col.cx = 400;
+    col.pszText = (LPWSTR)L"Value";
+    ListView_InsertColumn(hList_, 1, &col);
+  }
+
+  void onSize() {
+    RECT r;
+    GetClientRect(hwnd_, &r);
+    int w = r.right - r.left;
+    int h = r.bottom - r.top;
+    int split = 250;
+    MoveWindow(hTree_, 0, 0, split, h, TRUE);
+    MoveWindow(hList_, split, 0, w - split, h, TRUE);
+  }
+
+  void refresh() {
+    vm_->refresh();
+    TreeView_DeleteAllItems(hTree_);
+    hwnd_storage_.clear(); // Clear old strings to prevent leaks
+    for (const auto &node : vm_->tree()) {
+      addNode(TVI_ROOT, node);
     }
+  }
 
-    void refresh() {
-        vm_->refresh();
-        TreeView_DeleteAllItems(hTree_);
-        hwnd_storage_.clear(); // Clear old strings to prevent leaks
-        for (const auto& node : vm_->tree()) {
-            addNode(TVI_ROOT, node);
-        }
+  void addNode(HTREEITEM parent, const Node &n) {
+    TVINSERTSTRUCTW tvi = {0};
+    tvi.hParent = parent;
+    tvi.hInsertAfter = TVI_LAST;
+    tvi.item.mask = TVIF_TEXT | TVIF_PARAM;
+    std::wstring wlabel(n.label.begin(), n.label.end()); // Simple conversion
+    tvi.item.pszText = (LPWSTR)wlabel.c_str();
+
+    // Use a managed vector for HWND strings to avoid memory leaks
+    hwnd_storage_.push_back(n.hwnd);
+    tvi.item.lParam = (LPARAM)(hwnd_storage_.size() - 1);
+
+    HTREEITEM hItem = TreeView_InsertItem(hTree_, &tvi);
+    for (const auto &child : n.children)
+      addNode(hItem, child);
+  }
+
+  void onNotify(LPARAM lParam) {
+    LPNMHDR nm = (LPNMHDR)lParam;
+    if (nm->code == TVN_SELCHANGEDW) {
+      LPNMTREEVIEWW nmtv = (LPNMTREEVIEWW)lParam;
+      size_t idx = (size_t)nmtv->itemNew.lParam;
+      if (idx < hwnd_storage_.size()) {
+        vm_->select_hwnd(hwnd_storage_[idx]);
+        updateProps();
+      }
     }
+  }
 
-    void addNode(HTREEITEM parent, const Node& n) {
-        TVINSERTSTRUCTW tvi = { 0 };
-        tvi.hParent = parent;
-        tvi.hInsertAfter = TVI_LAST;
-        tvi.item.mask = TVIF_TEXT | TVIF_PARAM;
-        std::wstring wlabel(n.label.begin(), n.label.end()); // Simple conversion
-        tvi.item.pszText = (LPWSTR)wlabel.c_str();
-        
-        // Use a managed vector for HWND strings to avoid memory leaks
-        hwnd_storage_.push_back(n.hwnd);
-        tvi.item.lParam = (LPARAM)(hwnd_storage_.size() - 1); 
+  void updateProps() {
+    ListView_DeleteAllItems(hList_);
+    int i = 0;
+    for (const auto &p : vm_->props()) {
+      LVITEMW item = {0};
+      item.mask = LVIF_TEXT;
+      item.iItem = i;
+      item.iSubItem = 0;
+      std::wstring wk(p.key.begin(), p.key.end());
+      item.pszText = (LPWSTR)wk.c_str();
+      ListView_InsertItem(hList_, &item);
 
-        HTREEITEM hItem = TreeView_InsertItem(hTree_, &tvi);
-        for (const auto& child : n.children) addNode(hItem, child);
+      std::wstring wv(p.value.begin(), p.value.end());
+      ListView_SetItemText(hList_, i, 1, (LPWSTR)wv.c_str());
+      i++;
     }
+  }
 
-    void onNotify(LPARAM lParam) {
-        LPNMHDR nm = (LPNMHDR)lParam;
-        if (nm->code == TVN_SELCHANGEDW) {
-            LPNMTREEVIEWW nmtv = (LPNMTREEVIEWW)lParam;
-            size_t idx = (size_t)nmtv->itemNew.lParam;
-            if (idx < hwnd_storage_.size()) {
-                vm_->select_hwnd(hwnd_storage_[idx]);
-                updateProps();
-            }
-        }
-    }
-
-    void updateProps() {
-        ListView_DeleteAllItems(hList_);
-        int i = 0;
-        for (const auto& p : vm_->props()) {
-            LVITEMW item = { 0 };
-            item.mask = LVIF_TEXT;
-            item.iItem = i;
-            item.iSubItem = 0;
-            std::wstring wk(p.key.begin(), p.key.end());
-            item.pszText = (LPWSTR)wk.c_str();
-            ListView_InsertItem(hList_, &item);
-
-            std::wstring wv(p.value.begin(), p.value.end());
-            ListView_SetItemText(hList_, i, 1, (LPWSTR)wv.c_str());
-            i++;
-        }
-    }
-
-    HWND hwnd_ = nullptr;
-    HWND hTree_ = nullptr;
-    HWND hList_ = nullptr;
-    HINSTANCE hInst_ = nullptr;
-    std::unique_ptr<ViewModel> vm_;
-    std::unique_ptr<ITransport> transport_;
-    std::vector<std::string> hwnd_storage_;
+  HWND hwnd_ = nullptr;
+  HWND hTree_ = nullptr;
+  HWND hList_ = nullptr;
+  HINSTANCE hInst_ = nullptr;
+  std::unique_ptr<ViewModel> vm_;
+  std::unique_ptr<ITransport> transport_;
+  std::vector<std::string> hwnd_storage_;
 };
 
 int WINAPI wWinMain(HINSTANCE hInst, HINSTANCE, PWSTR, int nCmdShow) {
-    INITCOMMONCONTROLSEX icc{ sizeof(icc), ICC_TREEVIEW_CLASSES | ICC_LISTVIEW_CLASSES };
-    InitCommonControlsEx(&icc);
+  INITCOMMONCONTROLSEX icc{sizeof(icc),
+                           ICC_TREEVIEW_CLASSES | ICC_LISTVIEW_CLASSES};
+  InitCommonControlsEx(&icc);
 
-    WinInspectWindow win;
-    if (!win.init(hInst)) return 1;
-    win.show(nCmdShow);
+  WinInspectWindow win;
+  if (!win.init(hInst))
+    return 1;
+  win.show(nCmdShow);
 
-    MSG msg;
-    while (GetMessage(&msg, nullptr, 0, 0)) {
-        TranslateMessage(&msg);
-        DispatchMessage(&msg);
-    }
-    return 0;
+  MSG msg;
+  while (GetMessage(&msg, nullptr, 0, 0)) {
+    TranslateMessage(&msg);
+    DispatchMessage(&msg);
+  }
+  return 0;
 }
 #else
 int main() { return 0; }

--- a/clients/gui/src/gui_stub.cpp
+++ b/clients/gui/src/gui_stub.cpp
@@ -1,19 +1,22 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
 #include <commctrl.h>
+#include <windows.h>
 #pragma comment(lib, "comctl32.lib")
 
-// This is an intentionally minimal GUI stub. The testable logic lives in ViewModel.
-// Expand to TreeView + ListView shell.
+// This is an intentionally minimal GUI stub. The testable logic lives in
+// ViewModel. Expand to TreeView + ListView shell.
 
 int WINAPI wWinMain(HINSTANCE hInst, HINSTANCE, PWSTR, int nCmdShow) {
-  INITCOMMONCONTROLSEX icc{ sizeof(icc), ICC_TREEVIEW_CLASSES | ICC_LISTVIEW_CLASSES };
+  INITCOMMONCONTROLSEX icc{sizeof(icc),
+                           ICC_TREEVIEW_CLASSES | ICC_LISTVIEW_CLASSES};
   InitCommonControlsEx(&icc);
 
-  MessageBoxW(nullptr, L"WinInspect GUI stub. Implement TreeView/ListView shell next.", L"WinInspect", MB_OK);
+  MessageBoxW(nullptr,
+              L"WinInspect GUI stub. Implement TreeView/ListView shell next.",
+              L"WinInspect", MB_OK);
   return 0;
 }
 #else
-int main(){return 0;}
+int main() { return 0; }
 #endif

--- a/clients/gui/tests/test_viewmodel.cpp
+++ b/clients/gui/tests/test_viewmodel.cpp
@@ -1,60 +1,72 @@
-#include "doctest/doctest.h"
 #include "../viewmodel/viewmodel.hpp"
+#include "doctest/doctest.h"
 #include "wininspect/tinyjson.hpp"
 #include <map>
 
 using namespace wininspect_gui;
 
 struct FakeTransport : ITransport {
-  // Very small fake: returns snapshot_id "s-1", listTop two windows, getInfo fixed.
+  // Very small fake: returns snapshot_id "s-1", listTop two windows, getInfo
+  // fixed.
   int snap = 0;
-  std::string request(const std::string& json) override {
+  std::string request(const std::string &json) override {
     auto req = wininspect::json::parse(json).as_obj();
     auto method = req.at("method").as_str();
     if (method == "snapshot.capture") {
       snap++;
       wininspect::json::Object resp;
-      resp["id"]=req.at("id").as_str();
-      resp["ok"]=true;
+      resp["id"] = req.at("id").as_str();
+      resp["ok"] = true;
       wininspect::json::Object r;
-      r["snapshot_id"]=std::string("s-")+std::to_string(snap);
-      resp["result"]=r;
+      r["snapshot_id"] = std::string("s-") + std::to_string(snap);
+      resp["result"] = r;
       return wininspect::json::dumps(resp);
     }
     if (method == "window.listTop") {
       wininspect::json::Object resp;
-      resp["id"]=req.at("id").as_str();
-      resp["ok"]=true;
+      resp["id"] = req.at("id").as_str();
+      resp["ok"] = true;
       wininspect::json::Array arr;
-      wininspect::json::Object a; a["hwnd"]="0x1";
-      wininspect::json::Object b; b["hwnd"]="0x2";
-      arr.push_back(a); arr.push_back(b);
-      resp["result"]=arr;
+      wininspect::json::Object a;
+      a["hwnd"] = "0x1";
+      wininspect::json::Object b;
+      b["hwnd"] = "0x2";
+      arr.push_back(a);
+      arr.push_back(b);
+      resp["result"] = arr;
       return wininspect::json::dumps(resp);
     }
     if (method == "window.getInfo") {
       wininspect::json::Object resp;
-      resp["id"]=req.at("id").as_str();
-      resp["ok"]=true;
+      resp["id"] = req.at("id").as_str();
+      resp["ok"] = true;
       wininspect::json::Object info;
-      info["hwnd"]=req.at("params").as_obj().at("hwnd").as_str();
-      info["class_name"]="C1";
-      info["title"]="T";
-      info["parent"]="0x0";
-      info["owner"]="0x0";
-      info["window_rect"]=wininspect::json::Object{};
-      info["client_rect"]=wininspect::json::Object{};
-      info["pid"]=123.0; info["tid"]=456.0;
-      info["style"]="0x0"; info["exstyle"]="0x0";
-      info["visible"]=true; info["enabled"]=true; info["iconic"]=false; info["zoomed"]=false;
-      info["process_image"]="fake.exe";
-      resp["result"]=info;
+      info["hwnd"] = req.at("params").as_obj().at("hwnd").as_str();
+      info["class_name"] = "C1";
+      info["title"] = "T";
+      info["parent"] = "0x0";
+      info["owner"] = "0x0";
+      info["window_rect"] = wininspect::json::Object{};
+      info["client_rect"] = wininspect::json::Object{};
+      info["pid"] = 123.0;
+      info["tid"] = 456.0;
+      info["style"] = "0x0";
+      info["exstyle"] = "0x0";
+      info["visible"] = true;
+      info["enabled"] = true;
+      info["iconic"] = false;
+      info["zoomed"] = false;
+      info["process_image"] = "fake.exe";
+      resp["result"] = info;
       return wininspect::json::dumps(resp);
     }
     wininspect::json::Object err;
-    err["id"]=req.at("id").as_str(); err["ok"]=false;
-    wininspect::json::Object e; e["code"]="E_BAD_METHOD"; e["message"]="bad";
-    err["error"]=e;
+    err["id"] = req.at("id").as_str();
+    err["ok"] = false;
+    wininspect::json::Object e;
+    e["code"] = "E_BAD_METHOD";
+    e["message"] = "bad";
+    err["error"] = e;
     return wininspect::json::dumps(err);
   }
 };

--- a/clients/gui/viewmodel/viewmodel.cpp
+++ b/clients/gui/viewmodel/viewmodel.cpp
@@ -1,31 +1,35 @@
 #include "viewmodel.hpp"
 #include "wininspect/tinyjson.hpp"
 
-using wininspect::json::Object;
 using wininspect::json::Array;
+using wininspect::json::Object;
 
 namespace wininspect_gui {
 
-static std::string dumps(const Object& o) {
-  return wininspect::json::dumps(o);
-}
+static std::string dumps(const Object &o) { return wininspect::json::dumps(o); }
 
-ViewModel::ViewModel(ITransport* t) : t_(t) {}
+ViewModel::ViewModel(ITransport *t) : t_(t) {}
 
 void ViewModel::refresh() {
   // Capture snapshot and list top windows
-  Object cap; cap["id"]="gui-1"; cap["method"]="snapshot.capture"; cap["params"]=Object{};
-  cap["params"].obj()["canonical"]=true;
+  Object cap;
+  cap["id"] = "gui-1";
+  cap["method"] = "snapshot.capture";
+  cap["params"] = Object{};
+  cap["params"].obj()["canonical"] = true;
   auto cap_resp = wininspect::json::parse(t_->request(dumps(cap))).as_obj();
   auto sid = cap_resp.at("result").as_obj().at("snapshot_id").as_str();
 
-  Object req; req["id"]="gui-2"; req["method"]="window.listTop"; req["params"]=Object{};
-  req["params"].obj()["canonical"]=true;
-  req["params"].obj()["snapshot_id"]=sid;
+  Object req;
+  req["id"] = "gui-2";
+  req["method"] = "window.listTop";
+  req["params"] = Object{};
+  req["params"].obj()["canonical"] = true;
+  req["params"].obj()["snapshot_id"] = sid;
   auto resp = wininspect::json::parse(t_->request(dumps(req))).as_obj();
 
   tree_.clear();
-  for (const auto& e : resp.at("result").as_arr()) {
+  for (const auto &e : resp.at("result").as_arr()) {
     Node n;
     n.hwnd = e.as_obj().at("hwnd").as_str();
     n.label = n.hwnd;
@@ -33,23 +37,29 @@ void ViewModel::refresh() {
   }
 }
 
-void ViewModel::select_hwnd(const std::string& hwnd) {
+void ViewModel::select_hwnd(const std::string &hwnd) {
   // Capture snapshot and get info
-  Object cap; cap["id"]="gui-3"; cap["method"]="snapshot.capture"; cap["params"]=Object{};
-  cap["params"].obj()["canonical"]=true;
+  Object cap;
+  cap["id"] = "gui-3";
+  cap["method"] = "snapshot.capture";
+  cap["params"] = Object{};
+  cap["params"].obj()["canonical"] = true;
   auto cap_resp = wininspect::json::parse(t_->request(dumps(cap))).as_obj();
   auto sid = cap_resp.at("result").as_obj().at("snapshot_id").as_str();
 
-  Object req; req["id"]="gui-4"; req["method"]="window.getInfo"; req["params"]=Object{};
-  req["params"].obj()["canonical"]=true;
-  req["params"].obj()["snapshot_id"]=sid;
-  req["params"].obj()["hwnd"]=hwnd;
+  Object req;
+  req["id"] = "gui-4";
+  req["method"] = "window.getInfo";
+  req["params"] = Object{};
+  req["params"].obj()["canonical"] = true;
+  req["params"].obj()["snapshot_id"] = sid;
+  req["params"].obj()["hwnd"] = hwnd;
 
   auto resp = wininspect::json::parse(t_->request(dumps(req))).as_obj();
   props_.clear();
   if (resp.at("ok").as_bool()) {
     auto info = resp.at("result").as_obj();
-    for (const auto& [k,v] : info) {
+    for (const auto &[k, v] : info) {
       Property p;
       p.key = k;
       p.value = wininspect::json::dumps(v);

--- a/clients/gui/viewmodel/viewmodel.hpp
+++ b/clients/gui/viewmodel/viewmodel.hpp
@@ -1,7 +1,7 @@
 #pragma once
+#include <functional>
 #include <string>
 #include <vector>
-#include <functional>
 
 namespace wininspect_gui {
 
@@ -18,22 +18,22 @@ struct Property {
 
 struct ITransport {
   virtual ~ITransport() = default;
-  virtual std::string request(const std::string& json) = 0; // sync for v1
+  virtual std::string request(const std::string &json) = 0; // sync for v1
 };
 
 class ViewModel {
 public:
-  explicit ViewModel(ITransport* t);
+  explicit ViewModel(ITransport *t);
 
   // Pure-ish operations that can be unit tested.
   void refresh();
-  void select_hwnd(const std::string& hwnd);
+  void select_hwnd(const std::string &hwnd);
 
-  const std::vector<Node>& tree() const { return tree_; }
-  const std::vector<Property>& props() const { return props_; }
+  const std::vector<Node> &tree() const { return tree_; }
+  const std::vector<Property> &props() const { return props_; }
 
 private:
-  ITransport* t_;
+  ITransport *t_;
   std::vector<Node> tree_;
   std::vector<Property> props_;
 };

--- a/core/include/wininspect/backend.hpp
+++ b/core/include/wininspect/backend.hpp
@@ -15,21 +15,26 @@ public:
 
   virtual Snapshot capture_snapshot() = 0;
 
-  virtual std::vector<hwnd_u64> list_top(const Snapshot& s) = 0;
-  virtual std::vector<hwnd_u64> list_children(const Snapshot& s, hwnd_u64 parent) = 0;
-  virtual std::optional<WindowInfo> get_info(const Snapshot& s, hwnd_u64 hwnd) = 0;
-  virtual std::optional<hwnd_u64> pick_at_point(const Snapshot& s, int x, int y, PickFlags flags) = 0;
+  virtual std::vector<hwnd_u64> list_top(const Snapshot &s) = 0;
+  virtual std::vector<hwnd_u64> list_children(const Snapshot &s,
+                                              hwnd_u64 parent) = 0;
+  virtual std::optional<WindowInfo> get_info(const Snapshot &s,
+                                             hwnd_u64 hwnd) = 0;
+  virtual std::optional<hwnd_u64> pick_at_point(const Snapshot &s, int x, int y,
+                                                PickFlags flags) = 0;
 
   // Desired-state actions (may be no-op in some environments)
   virtual EnsureResult ensure_visible(hwnd_u64 hwnd, bool visible) = 0;
   virtual EnsureResult ensure_foreground(hwnd_u64 hwnd) = 0;
 
   // Event injection
-  virtual bool post_message(hwnd_u64 hwnd, uint32_t msg, uint64_t wparam, uint64_t lparam) = 0;
-  virtual bool send_input(const std::vector<uint8_t>& raw_input_data) = 0;
+  virtual bool post_message(hwnd_u64 hwnd, uint32_t msg, uint64_t wparam,
+                            uint64_t lparam) = 0;
+  virtual bool send_input(const std::vector<uint8_t> &raw_input_data) = 0;
 
   // Event polling
-  virtual std::vector<Event> poll_events(const Snapshot& old_snap, const Snapshot& new_snap) = 0;
+  virtual std::vector<Event> poll_events(const Snapshot &old_snap,
+                                         const Snapshot &new_snap) = 0;
 };
 
 } // namespace wininspect

--- a/core/include/wininspect/core.hpp
+++ b/core/include/wininspect/core.hpp
@@ -23,16 +23,18 @@ struct CoreResponse {
 
 class CoreEngine {
 public:
-  explicit CoreEngine(IBackend* backend);
+  explicit CoreEngine(IBackend *backend);
 
-  // Handle one request. Core itself is stateless; snapshot state lives in daemon layer.
-  CoreResponse handle(const CoreRequest& req, const Snapshot& snapshot, const Snapshot* old_snapshot = nullptr);
+  // Handle one request. Core itself is stateless; snapshot state lives in
+  // daemon layer.
+  CoreResponse handle(const CoreRequest &req, const Snapshot &snapshot,
+                      const Snapshot *old_snapshot = nullptr);
 
 private:
-  IBackend* backend_;
+  IBackend *backend_;
 };
 
 CoreRequest parse_request_json(std::string_view json_utf8);
-std::string serialize_response_json(const CoreResponse& resp, bool canonical);
+std::string serialize_response_json(const CoreResponse &resp, bool canonical);
 
 } // namespace wininspect

--- a/core/include/wininspect/crypto.hpp
+++ b/core/include/wininspect/crypto.hpp
@@ -1,54 +1,50 @@
 #pragma once
+#include <cstdint>
 #include <string>
 #include <vector>
-#include <cstdint>
 
 namespace wininspect::crypto {
 
 struct Signature {
-    std::string identity;
-    std::vector<uint8_t> blob;
+  std::string identity;
+  std::vector<uint8_t> blob;
 };
 
 // Key exchange and session state
 class CryptoSession {
 public:
-    CryptoSession();
-    ~CryptoSession();
+  CryptoSession();
+  ~CryptoSession();
 
-    // Generates a local X25519 key pair and returns the public key
-    std::vector<uint8_t> generate_local_key();
+  // Generates a local X25519 key pair and returns the public key
+  std::vector<uint8_t> generate_local_key();
 
-    // Computes the shared secret and initializes symmetric encryption
-    bool compute_shared_secret(const std::vector<uint8_t>& remote_pubkey);
+  // Computes the shared secret and initializes symmetric encryption
+  bool compute_shared_secret(const std::vector<uint8_t> &remote_pubkey);
 
-    // Encrypts a message using AES-256-GCM
-    std::vector<uint8_t> encrypt(const std::string& plaintext);
+  // Encrypts a message using AES-256-GCM
+  std::vector<uint8_t> encrypt(const std::string &plaintext);
 
-    // Decrypts a message using AES-256-GCM
-    std::string decrypt(const std::vector<uint8_t>& ciphertext);
+  // Decrypts a message using AES-256-GCM
+  std::string decrypt(const std::vector<uint8_t> &ciphertext);
 
-    bool is_initialized() const { return initialized_; }
+  bool is_initialized() const { return initialized_; }
 
 private:
-    bool initialized_ = false;
-    void* hAlgAES_ = nullptr;
-    void* hKeyAES_ = nullptr;
-    uint64_t nonce_counter_ = 0;
-    std::vector<uint8_t> shared_secret_;
+  bool initialized_ = false;
+  void *hAlgAES_ = nullptr;
+  void *hKeyAES_ = nullptr;
+  uint64_t nonce_counter_ = 0;
+  std::vector<uint8_t> shared_secret_;
 };
 
 // Verifies an Ed25519 SSH signature against an authorized_keys-style entry
-bool verify_ssh_sig(
-    const std::vector<uint8_t>& message,
-    const std::string& signature_b64,
-    const std::string& public_key_line
-);
+bool verify_ssh_sig(const std::vector<uint8_t> &message,
+                    const std::string &signature_b64,
+                    const std::string &public_key_line);
 
 // Signs a message using an Ed25519 private key (OpenSSH format)
-std::string sign_ssh_msg(
-    const std::vector<uint8_t>& message,
-    const std::string& private_key_path
-);
+std::string sign_ssh_msg(const std::vector<uint8_t> &message,
+                         const std::string &private_key_path);
 
 } // namespace wininspect::crypto

--- a/core/include/wininspect/fake_backend.hpp
+++ b/core/include/wininspect/fake_backend.hpp
@@ -20,18 +20,22 @@ public:
 
   Snapshot capture_snapshot() override;
 
-  std::vector<hwnd_u64> list_top(const Snapshot& s) override;
-  std::vector<hwnd_u64> list_children(const Snapshot& s, hwnd_u64 parent) override;
-  std::optional<WindowInfo> get_info(const Snapshot& s, hwnd_u64 hwnd) override;
-  std::optional<hwnd_u64> pick_at_point(const Snapshot& s, int x, int y, PickFlags flags) override;
+  std::vector<hwnd_u64> list_top(const Snapshot &s) override;
+  std::vector<hwnd_u64> list_children(const Snapshot &s,
+                                      hwnd_u64 parent) override;
+  std::optional<WindowInfo> get_info(const Snapshot &s, hwnd_u64 hwnd) override;
+  std::optional<hwnd_u64> pick_at_point(const Snapshot &s, int x, int y,
+                                        PickFlags flags) override;
 
   EnsureResult ensure_visible(hwnd_u64 hwnd, bool visible) override;
   EnsureResult ensure_foreground(hwnd_u64 hwnd) override;
 
-  bool post_message(hwnd_u64 hwnd, uint32_t msg, uint64_t wparam, uint64_t lparam) override;
-  bool send_input(const std::vector<uint8_t>& raw_input_data) override;
+  bool post_message(hwnd_u64 hwnd, uint32_t msg, uint64_t wparam,
+                    uint64_t lparam) override;
+  bool send_input(const std::vector<uint8_t> &raw_input_data) override;
 
-  std::vector<Event> poll_events(const Snapshot& old_snap, const Snapshot& new_snap) override;
+  std::vector<Event> poll_events(const Snapshot &old_snap,
+                                 const Snapshot &new_snap) override;
 
 private:
   std::mutex mu_;

--- a/core/include/wininspect/tinyjson.hpp
+++ b/core/include/wininspect/tinyjson.hpp
@@ -12,28 +12,28 @@ namespace wininspect::json {
 
 struct Value;
 using Object = std::map<std::string, Value>;
-using Array  = std::vector<Value>;
-using Null   = std::monostate;
+using Array = std::vector<Value>;
+using Null = std::monostate;
 
 struct Value : std::variant<Null, bool, double, std::string, Array, Object> {
   using variant::variant;
 
-  bool is_null()   const { return std::holds_alternative<Null>(*this); }
-  bool is_bool()   const { return std::holds_alternative<bool>(*this); }
-  bool is_num()    const { return std::holds_alternative<double>(*this); }
-  bool is_str()    const { return std::holds_alternative<std::string>(*this); }
-  bool is_arr()    const { return std::holds_alternative<Array>(*this); }
-  bool is_obj()    const { return std::holds_alternative<Object>(*this); }
+  bool is_null() const { return std::holds_alternative<Null>(*this); }
+  bool is_bool() const { return std::holds_alternative<bool>(*this); }
+  bool is_num() const { return std::holds_alternative<double>(*this); }
+  bool is_str() const { return std::holds_alternative<std::string>(*this); }
+  bool is_arr() const { return std::holds_alternative<Array>(*this); }
+  bool is_obj() const { return std::holds_alternative<Object>(*this); }
 
-  const Object& as_obj() const { return std::get<Object>(*this); }
-  const Array&  as_arr() const { return std::get<Array>(*this); }
-  const std::string& as_str() const { return std::get<std::string>(*this); }
+  const Object &as_obj() const { return std::get<Object>(*this); }
+  const Array &as_arr() const { return std::get<Array>(*this); }
+  const std::string &as_str() const { return std::get<std::string>(*this); }
   double as_num() const { return std::get<double>(*this); }
   bool as_bool() const { return std::get<bool>(*this); }
 
-  Object& obj() { return std::get<Object>(*this); }
-  Array&  arr() { return std::get<Array>(*this); }
-  std::string& str() { return std::get<std::string>(*this); }
+  Object &obj() { return std::get<Object>(*this); }
+  Array &arr() { return std::get<Array>(*this); }
+  std::string &str() { return std::get<std::string>(*this); }
 };
 
 class ParseError : public std::runtime_error {
@@ -49,7 +49,8 @@ public:
     skip_ws();
     Value v = parse_value();
     skip_ws();
-    if (i_ != s_.size()) throw ParseError("trailing characters");
+    if (i_ != s_.size())
+      throw ParseError("trailing characters");
     return v;
   }
 
@@ -58,28 +59,38 @@ private:
   size_t i_ = 0;
 
   void skip_ws() {
-    while (i_ < s_.size() && std::isspace((unsigned char)s_[i_])) i_++;
+    while (i_ < s_.size() && std::isspace((unsigned char)s_[i_]))
+      i_++;
   }
 
   char peek() const {
-    if (i_ >= s_.size()) return '\0';
+    if (i_ >= s_.size())
+      return '\0';
     return s_[i_];
   }
 
   char get() {
-    if (i_ >= s_.size()) throw ParseError("unexpected end");
+    if (i_ >= s_.size())
+      throw ParseError("unexpected end");
     return s_[i_++];
   }
 
   Value parse_value() {
     char c = peek();
-    if (c == '{') return parse_object();
-    if (c == '[') return parse_array();
-    if (c == '"') return parse_string();
-    if (c == 't') return parse_true();
-    if (c == 'f') return parse_false();
-    if (c == 'n') return parse_null();
-    if (c == '-' || std::isdigit((unsigned char)c)) return parse_number();
+    if (c == '{')
+      return parse_object();
+    if (c == '[')
+      return parse_array();
+    if (c == '"')
+      return parse_string();
+    if (c == 't')
+      return parse_true();
+    if (c == 'f')
+      return parse_false();
+    if (c == 'n')
+      return parse_null();
+    if (c == '-' || std::isdigit((unsigned char)c))
+      return parse_number();
     throw ParseError("invalid value");
   }
 
@@ -87,19 +98,26 @@ private:
     Object obj;
     get(); // {
     skip_ws();
-    if (peek() == '}') { get(); return obj; }
+    if (peek() == '}') {
+      get();
+      return obj;
+    }
     while (true) {
       skip_ws();
-      if (peek() != '"') throw ParseError("expected string key");
+      if (peek() != '"')
+        throw ParseError("expected string key");
       std::string key = std::get<std::string>(parse_string());
       skip_ws();
-      if (get() != ':') throw ParseError("expected ':'");
+      if (get() != ':')
+        throw ParseError("expected ':'");
       skip_ws();
       obj.emplace(std::move(key), parse_value());
       skip_ws();
       char c = get();
-      if (c == '}') break;
-      if (c != ',') throw ParseError("expected ',' or '}'");
+      if (c == '}')
+        break;
+      if (c != ',')
+        throw ParseError("expected ',' or '}'");
       skip_ws();
     }
     return obj;
@@ -109,60 +127,90 @@ private:
     Array arr;
     get(); // [
     skip_ws();
-    if (peek() == ']') { get(); return arr; }
+    if (peek() == ']') {
+      get();
+      return arr;
+    }
     while (true) {
       skip_ws();
       arr.push_back(parse_value());
       skip_ws();
       char c = get();
-      if (c == ']') break;
-      if (c != ',') throw ParseError("expected ',' or ']'");
+      if (c == ']')
+        break;
+      if (c != ',')
+        throw ParseError("expected ',' or ']'");
       skip_ws();
     }
     return arr;
   }
 
   static int hexval(char c) {
-    if (c >= '0' && c <= '9') return c - '0';
-    if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
-    if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+    if (c >= '0' && c <= '9')
+      return c - '0';
+    if (c >= 'a' && c <= 'f')
+      return 10 + (c - 'a');
+    if (c >= 'A' && c <= 'F')
+      return 10 + (c - 'A');
     return -1;
   }
 
   Value parse_string() {
     std::string out;
-    if (get() != '"') throw ParseError("expected '\"'");
+    if (get() != '"')
+      throw ParseError("expected '\"'");
     while (true) {
       char c = get();
-      if (c == '"') break;
+      if (c == '"')
+        break;
       if (c == '\\') {
         char e = get();
         switch (e) {
-          case '"': out.push_back('"'); break;
-          case '\\': out.push_back('\\'); break;
-          case '/': out.push_back('/'); break;
-          case 'b': out.push_back('\b'); break;
-          case 'f': out.push_back('\f'); break;
-          case 'n': out.push_back('\n'); break;
-          case 'r': out.push_back('\r'); break;
-          case 't': out.push_back('\t'); break;
-          case 'u': {
-            int h1=hexval(get()), h2=hexval(get()), h3=hexval(get()), h4=hexval(get());
-            if (h1<0||h2<0||h3<0||h4<0) throw ParseError("bad unicode escape");
-            uint16_t code = (uint16_t)((h1<<12)|(h2<<8)|(h3<<4)|h4);
-            // Minimal UTF-8 encoding for BMP
-            if (code < 0x80) out.push_back((char)code);
-            else if (code < 0x800) {
-              out.push_back((char)(0xC0 | (code>>6)));
-              out.push_back((char)(0x80 | (code & 0x3F)));
-            } else {
-              out.push_back((char)(0xE0 | (code>>12)));
-              out.push_back((char)(0x80 | ((code>>6) & 0x3F)));
-              out.push_back((char)(0x80 | (code & 0x3F)));
-            }
-            break;
+        case '"':
+          out.push_back('"');
+          break;
+        case '\\':
+          out.push_back('\\');
+          break;
+        case '/':
+          out.push_back('/');
+          break;
+        case 'b':
+          out.push_back('\b');
+          break;
+        case 'f':
+          out.push_back('\f');
+          break;
+        case 'n':
+          out.push_back('\n');
+          break;
+        case 'r':
+          out.push_back('\r');
+          break;
+        case 't':
+          out.push_back('\t');
+          break;
+        case 'u': {
+          int h1 = hexval(get()), h2 = hexval(get()), h3 = hexval(get()),
+              h4 = hexval(get());
+          if (h1 < 0 || h2 < 0 || h3 < 0 || h4 < 0)
+            throw ParseError("bad unicode escape");
+          uint16_t code = (uint16_t)((h1 << 12) | (h2 << 8) | (h3 << 4) | h4);
+          // Minimal UTF-8 encoding for BMP
+          if (code < 0x80)
+            out.push_back((char)code);
+          else if (code < 0x800) {
+            out.push_back((char)(0xC0 | (code >> 6)));
+            out.push_back((char)(0x80 | (code & 0x3F)));
+          } else {
+            out.push_back((char)(0xE0 | (code >> 12)));
+            out.push_back((char)(0x80 | ((code >> 6) & 0x3F)));
+            out.push_back((char)(0x80 | (code & 0x3F)));
           }
-          default: throw ParseError("bad escape");
+          break;
+        }
+        default:
+          throw ParseError("bad escape");
         }
       } else {
         out.push_back(c);
@@ -172,41 +220,53 @@ private:
   }
 
   Value parse_true() {
-    if (s_.substr(i_, 4) != "true") throw ParseError("expected true");
+    if (s_.substr(i_, 4) != "true")
+      throw ParseError("expected true");
     i_ += 4;
     return true;
   }
 
   Value parse_false() {
-    if (s_.substr(i_, 5) != "false") throw ParseError("expected false");
+    if (s_.substr(i_, 5) != "false")
+      throw ParseError("expected false");
     i_ += 5;
     return false;
   }
 
   Value parse_null() {
-    if (s_.substr(i_, 4) != "null") throw ParseError("expected null");
+    if (s_.substr(i_, 4) != "null")
+      throw ParseError("expected null");
     i_ += 4;
     return Null{};
   }
 
   Value parse_number() {
     size_t start = i_;
-    if (peek() == '-') get();
-    if (peek() == '0') get();
+    if (peek() == '-')
+      get();
+    if (peek() == '0')
+      get();
     else {
-      if (!std::isdigit((unsigned char)peek())) throw ParseError("bad number");
-      while (std::isdigit((unsigned char)peek())) get();
+      if (!std::isdigit((unsigned char)peek()))
+        throw ParseError("bad number");
+      while (std::isdigit((unsigned char)peek()))
+        get();
     }
     if (peek() == '.') {
       get();
-      if (!std::isdigit((unsigned char)peek())) throw ParseError("bad number");
-      while (std::isdigit((unsigned char)peek())) get();
+      if (!std::isdigit((unsigned char)peek()))
+        throw ParseError("bad number");
+      while (std::isdigit((unsigned char)peek()))
+        get();
     }
     if (peek() == 'e' || peek() == 'E') {
       get();
-      if (peek() == '+' || peek() == '-') get();
-      if (!std::isdigit((unsigned char)peek())) throw ParseError("bad number");
-      while (std::isdigit((unsigned char)peek())) get();
+      if (peek() == '+' || peek() == '-')
+        get();
+      if (!std::isdigit((unsigned char)peek()))
+        throw ParseError("bad number");
+      while (std::isdigit((unsigned char)peek()))
+        get();
     }
     double v = std::stod(std::string(s_.substr(start, i_ - start)));
     return v;
@@ -215,36 +275,53 @@ private:
 
 inline Value parse(std::string_view s) { return Parser(s).parse(); }
 
-// Stable serializer: object keys sorted (std::map does that), minimal formatting.
-inline void dump_string(std::string& out, const std::string& s) {
+// Stable serializer: object keys sorted (std::map does that), minimal
+// formatting.
+inline void dump_string(std::string &out, const std::string &s) {
   out.push_back('"');
   for (unsigned char c : s) {
     switch (c) {
-      case '"': out += "\\\""; break;
-      case '\\': out += "\\\\"; break;
-      case '\b': out += "\\b"; break;
-      case '\f': out += "\\f"; break;
-      case '\n': out += "\\n"; break;
-      case '\r': out += "\\r"; break;
-      case '\t': out += "\\t"; break;
-      default:
-        if (c < 0x20) {
-          char buf[7];
-          snprintf(buf, sizeof(buf), "\\u%04x", c);
-          out += buf;
-        } else out.push_back((char)c);
+    case '"':
+      out += "\\\"";
+      break;
+    case '\\':
+      out += "\\\\";
+      break;
+    case '\b':
+      out += "\\b";
+      break;
+    case '\f':
+      out += "\\f";
+      break;
+    case '\n':
+      out += "\\n";
+      break;
+    case '\r':
+      out += "\\r";
+      break;
+    case '\t':
+      out += "\\t";
+      break;
+    default:
+      if (c < 0x20) {
+        char buf[7];
+        snprintf(buf, sizeof(buf), "\\u%04x", c);
+        out += buf;
+      } else
+        out.push_back((char)c);
     }
   }
   out.push_back('"');
 }
 
-inline void dump(std::string& out, const Value& v);
+inline void dump(std::string &out, const Value &v);
 
-inline void dump_obj(std::string& out, const Object& o) {
+inline void dump_obj(std::string &out, const Object &o) {
   out.push_back('{');
   bool first = true;
-  for (const auto& [k,val] : o) {
-    if (!first) out.push_back(',');
+  for (const auto &[k, val] : o) {
+    if (!first)
+      out.push_back(',');
     first = false;
     dump_string(out, k);
     out.push_back(':');
@@ -253,34 +330,53 @@ inline void dump_obj(std::string& out, const Object& o) {
   out.push_back('}');
 }
 
-inline void dump_arr(std::string& out, const Array& a) {
+inline void dump_arr(std::string &out, const Array &a) {
   out.push_back('[');
   bool first = true;
-  for (const auto& v : a) {
-    if (!first) out.push_back(',');
+  for (const auto &v : a) {
+    if (!first)
+      out.push_back(',');
     first = false;
     dump(out, v);
   }
   out.push_back(']');
 }
 
-inline void dump(std::string& out, const Value& v) {
-  if (std::holds_alternative<Null>(v)) { out += "null"; return; }
-  if (std::holds_alternative<bool>(v)) { out += (std::get<bool>(v) ? "true" : "false"); return; }
+inline void dump(std::string &out, const Value &v) {
+  if (std::holds_alternative<Null>(v)) {
+    out += "null";
+    return;
+  }
+  if (std::holds_alternative<bool>(v)) {
+    out += (std::get<bool>(v) ? "true" : "false");
+    return;
+  }
   if (std::holds_alternative<double>(v)) {
     // deterministic-ish formatting: use std::to_string then trim
     std::string s = std::to_string(std::get<double>(v));
     // trim trailing zeros
-    while (s.size()>1 && s.find('.')!=std::string::npos && s.back()=='0') s.pop_back();
-    if (!s.empty() && s.back()=='.') s.pop_back();
+    while (s.size() > 1 && s.find('.') != std::string::npos && s.back() == '0')
+      s.pop_back();
+    if (!s.empty() && s.back() == '.')
+      s.pop_back();
     out += s;
     return;
   }
-  if (std::holds_alternative<std::string>(v)) { dump_string(out, std::get<std::string>(v)); return; }
-  if (std::holds_alternative<Array>(v)) { dump_arr(out, std::get<Array>(v)); return; }
+  if (std::holds_alternative<std::string>(v)) {
+    dump_string(out, std::get<std::string>(v));
+    return;
+  }
+  if (std::holds_alternative<Array>(v)) {
+    dump_arr(out, std::get<Array>(v));
+    return;
+  }
   dump_obj(out, std::get<Object>(v));
 }
 
-inline std::string dumps(const Value& v) { std::string out; dump(out, v); return out; }
+inline std::string dumps(const Value &v) {
+  std::string out;
+  dump(out, v);
+  return out;
+}
 
 } // namespace wininspect::json

--- a/core/include/wininspect/types.hpp
+++ b/core/include/wininspect/types.hpp
@@ -8,7 +8,9 @@ namespace wininspect {
 using hwnd_u64 = std::uint64_t;
 inline constexpr std::string_view PROTOCOL_VERSION = "1.0.0";
 
-struct Rect { long left{}, top{}, right{}, bottom{}; };
+struct Rect {
+  long left{}, top{}, right{}, bottom{};
+};
 
 struct WindowInfo {
   hwnd_u64 hwnd{};
@@ -41,9 +43,9 @@ struct Snapshot {
 };
 
 struct Event {
-    std::string type; // "window.created", "window.destroyed", "window.changed"
-    hwnd_u64 hwnd{};
-    std::string property; // for "window.changed"
+  std::string type; // "window.created", "window.destroyed", "window.changed"
+  hwnd_u64 hwnd{};
+  std::string property; // for "window.changed"
 };
 
 } // namespace wininspect

--- a/core/include/wininspect/win32_backend.hpp
+++ b/core/include/wininspect/win32_backend.hpp
@@ -7,18 +7,22 @@ class Win32Backend final : public IBackend {
 public:
   Snapshot capture_snapshot() override;
 
-  std::vector<hwnd_u64> list_top(const Snapshot& s) override;
-  std::vector<hwnd_u64> list_children(const Snapshot& s, hwnd_u64 parent) override;
-  std::optional<WindowInfo> get_info(const Snapshot& s, hwnd_u64 hwnd) override;
-  std::optional<hwnd_u64> pick_at_point(const Snapshot& s, int x, int y, PickFlags flags) override;
+  std::vector<hwnd_u64> list_top(const Snapshot &s) override;
+  std::vector<hwnd_u64> list_children(const Snapshot &s,
+                                      hwnd_u64 parent) override;
+  std::optional<WindowInfo> get_info(const Snapshot &s, hwnd_u64 hwnd) override;
+  std::optional<hwnd_u64> pick_at_point(const Snapshot &s, int x, int y,
+                                        PickFlags flags) override;
 
   EnsureResult ensure_visible(hwnd_u64 hwnd, bool visible) override;
   EnsureResult ensure_foreground(hwnd_u64 hwnd) override;
 
-  bool post_message(hwnd_u64 hwnd, uint32_t msg, uint64_t wparam, uint64_t lparam) override;
-  bool send_input(const std::vector<uint8_t>& raw_input_data) override;
+  bool post_message(hwnd_u64 hwnd, uint32_t msg, uint64_t wparam,
+                    uint64_t lparam) override;
+  bool send_input(const std::vector<uint8_t> &raw_input_data) override;
 
-  std::vector<Event> poll_events(const Snapshot& old_snap, const Snapshot& new_snap) override;
+  std::vector<Event> poll_events(const Snapshot &old_snap,
+                                 const Snapshot &new_snap) override;
 };
 
 } // namespace wininspect

--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -3,7 +3,7 @@
 
 namespace wininspect {
 
-static json::Value make_error(const std::string& code, const std::string& msg) {
+static json::Value make_error(const std::string &code, const std::string &msg) {
   json::Object e;
   e["code"] = code;
   e["message"] = msg;
@@ -14,39 +14,52 @@ json::Object CoreResponse::to_json_obj(bool /*canonical*/) const {
   json::Object o;
   o["id"] = id;
   o["ok"] = ok;
-  if (ok) o["result"] = result;
-  else o["error"] = make_error(error_code, error_message);
+  if (ok)
+    o["result"] = result;
+  else
+    o["error"] = make_error(error_code, error_message);
   return o;
 }
 
-CoreEngine::CoreEngine(IBackend* backend) : backend_(backend) {}
+CoreEngine::CoreEngine(IBackend *backend) : backend_(backend) {}
 
-static std::optional<std::string> get_str(const json::Object& o, const std::string& k) {
+static std::optional<std::string> get_str(const json::Object &o,
+                                          const std::string &k) {
   auto it = o.find(k);
-  if (it == o.end()) return std::nullopt;
-  if (!it->second.is_str()) return std::nullopt;
+  if (it == o.end())
+    return std::nullopt;
+  if (!it->second.is_str())
+    return std::nullopt;
   return it->second.as_str();
 }
-static std::optional<bool> get_bool(const json::Object& o, const std::string& k) {
+static std::optional<bool> get_bool(const json::Object &o,
+                                    const std::string &k) {
   auto it = o.find(k);
-  if (it == o.end()) return std::nullopt;
-  if (!it->second.is_bool()) return std::nullopt;
+  if (it == o.end())
+    return std::nullopt;
+  if (!it->second.is_bool())
+    return std::nullopt;
   return it->second.as_bool();
 }
-static std::optional<double> get_num(const json::Object& o, const std::string& k) {
+static std::optional<double> get_num(const json::Object &o,
+                                     const std::string &k) {
   auto it = o.find(k);
-  if (it == o.end()) return std::nullopt;
-  if (!it->second.is_num()) return std::nullopt;
+  if (it == o.end())
+    return std::nullopt;
+  if (!it->second.is_num())
+    return std::nullopt;
   return it->second.as_num();
 }
 
-static std::optional<hwnd_u64> parse_hwnd(const std::string& s) {
-  if (s.rfind("0x", 0) != 0) return std::nullopt;
+static std::optional<hwnd_u64> parse_hwnd(const std::string &s) {
+  if (s.rfind("0x", 0) != 0)
+    return std::nullopt;
   std::uint64_t v = 0;
   std::stringstream ss;
   ss << std::hex << s.substr(2);
   ss >> v;
-  if (ss.fail()) return std::nullopt;
+  if (ss.fail())
+    return std::nullopt;
   return (hwnd_u64)v;
 }
 
@@ -56,15 +69,16 @@ static std::string fmt_hwnd(hwnd_u64 h) {
   return oss.str();
 }
 
-static json::Object event_to_json(const Event& e) {
+static json::Object event_to_json(const Event &e) {
   json::Object o;
   o["type"] = e.type;
   o["hwnd"] = fmt_hwnd(e.hwnd);
-  if (!e.property.empty()) o["property"] = e.property;
+  if (!e.property.empty())
+    o["property"] = e.property;
   return o;
 }
 
-static json::Object window_info_to_json(const WindowInfo& wi) {
+static json::Object window_info_to_json(const WindowInfo &wi) {
   json::Object o;
   o["hwnd"] = fmt_hwnd(wi.hwnd);
   o["parent"] = fmt_hwnd(wi.parent);
@@ -72,12 +86,18 @@ static json::Object window_info_to_json(const WindowInfo& wi) {
   o["class_name"] = wi.class_name;
   o["title"] = wi.title;
 
-  json::Object wr; wr["left"]= (double)wi.window_rect.left; wr["top"]=(double)wi.window_rect.top;
-  wr["right"]=(double)wi.window_rect.right; wr["bottom"]=(double)wi.window_rect.bottom;
+  json::Object wr;
+  wr["left"] = (double)wi.window_rect.left;
+  wr["top"] = (double)wi.window_rect.top;
+  wr["right"] = (double)wi.window_rect.right;
+  wr["bottom"] = (double)wi.window_rect.bottom;
   o["window_rect"] = wr;
 
-  json::Object cr; cr["left"]= (double)wi.client_rect.left; cr["top"]=(double)wi.client_rect.top;
-  cr["right"]=(double)wi.client_rect.right; cr["bottom"]=(double)wi.client_rect.bottom;
+  json::Object cr;
+  cr["left"] = (double)wi.client_rect.left;
+  cr["top"] = (double)wi.client_rect.top;
+  cr["right"] = (double)wi.client_rect.right;
+  cr["bottom"] = (double)wi.client_rect.bottom;
   o["client_rect"] = cr;
 
   o["pid"] = (double)wi.pid;
@@ -96,14 +116,17 @@ static json::Object window_info_to_json(const WindowInfo& wi) {
 }
 
 static std::vector<uint8_t> base64_decode(std::string_view in) {
-  static const std::string_view b64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  static const std::string_view b64 =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
   std::vector<uint8_t> out;
   std::vector<int> T(256, -1);
-  for (int i = 0; i < 64; i++) T[b64[i]] = i;
+  for (int i = 0; i < 64; i++)
+    T[b64[i]] = i;
 
   int val = 0, valb = -8;
   for (char c : in) {
-    if (T[c] == -1) break;
+    if (T[c] == -1)
+      break;
     val = (val << 6) + T[c];
     valb += 6;
     if (valb >= 0) {
@@ -114,7 +137,9 @@ static std::vector<uint8_t> base64_decode(std::string_view in) {
   return out;
 }
 
-CoreResponse CoreEngine::handle(const CoreRequest& req, const Snapshot& snapshot, const Snapshot* old_snapshot) {
+CoreResponse CoreEngine::handle(const CoreRequest &req,
+                                const Snapshot &snapshot,
+                                const Snapshot *old_snapshot) {
   CoreResponse resp;
   resp.id = req.id;
   resp.ok = true;
@@ -122,10 +147,12 @@ CoreResponse CoreEngine::handle(const CoreRequest& req, const Snapshot& snapshot
 
   try {
     if (req.method == "events.poll") {
-      if (!old_snapshot) throw std::runtime_error("events.poll requires two snapshots");
+      if (!old_snapshot)
+        throw std::runtime_error("events.poll requires two snapshots");
       auto events = backend_->poll_events(*old_snapshot, snapshot);
       json::Array arr;
-      for (const auto& e : events) arr.push_back(event_to_json(e));
+      for (const auto &e : events)
+        arr.push_back(event_to_json(e));
       resp.result = arr;
       return resp;
     }
@@ -144,9 +171,11 @@ CoreResponse CoreEngine::handle(const CoreRequest& req, const Snapshot& snapshot
 
     if (req.method == "window.listChildren") {
       auto hwnd_s = get_str(req.params, "hwnd");
-      if (!hwnd_s) throw std::runtime_error("missing hwnd");
+      if (!hwnd_s)
+        throw std::runtime_error("missing hwnd");
       auto hwnd = parse_hwnd(*hwnd_s);
-      if (!hwnd) throw std::runtime_error("bad hwnd");
+      if (!hwnd)
+        throw std::runtime_error("bad hwnd");
       auto ch = backend_->list_children(snapshot, *hwnd);
       json::Array arr;
       for (auto h : ch) {
@@ -160,11 +189,18 @@ CoreResponse CoreEngine::handle(const CoreRequest& req, const Snapshot& snapshot
 
     if (req.method == "window.getInfo") {
       auto hwnd_s = get_str(req.params, "hwnd");
-      if (!hwnd_s) throw std::runtime_error("missing hwnd");
+      if (!hwnd_s)
+        throw std::runtime_error("missing hwnd");
       auto hwnd = parse_hwnd(*hwnd_s);
-      if (!hwnd) throw std::runtime_error("bad hwnd");
+      if (!hwnd)
+        throw std::runtime_error("bad hwnd");
       auto info = backend_->get_info(snapshot, *hwnd);
-      if (!info) { resp.ok=false; resp.error_code="E_BAD_HWND"; resp.error_message="not a valid window handle"; return resp; }
+      if (!info) {
+        resp.ok = false;
+        resp.error_code = "E_BAD_HWND";
+        resp.error_message = "not a valid window handle";
+        return resp;
+      }
       resp.result = window_info_to_json(*info);
       return resp;
     }
@@ -172,13 +208,22 @@ CoreResponse CoreEngine::handle(const CoreRequest& req, const Snapshot& snapshot
     if (req.method == "window.pickAtPoint") {
       auto x = get_num(req.params, "x");
       auto y = get_num(req.params, "y");
-      if (!x || !y) throw std::runtime_error("missing x/y");
+      if (!x || !y)
+        throw std::runtime_error("missing x/y");
       PickFlags flags;
-      if (auto b = get_bool(req.params, "prefer_child")) flags.prefer_child = *b;
-      if (auto b = get_bool(req.params, "ignore_transparent")) flags.ignore_transparent = *b;
+      if (auto b = get_bool(req.params, "prefer_child"))
+        flags.prefer_child = *b;
+      if (auto b = get_bool(req.params, "ignore_transparent"))
+        flags.ignore_transparent = *b;
       auto h = backend_->pick_at_point(snapshot, (int)*x, (int)*y, flags);
-      if (!h) { resp.ok=false; resp.error_code="E_NOT_FOUND"; resp.error_message="no window at point"; return resp; }
-      json::Object o; o["hwnd"] = fmt_hwnd(*h);
+      if (!h) {
+        resp.ok = false;
+        resp.error_code = "E_NOT_FOUND";
+        resp.error_message = "no window at point";
+        return resp;
+      }
+      json::Object o;
+      o["hwnd"] = fmt_hwnd(*h);
       resp.result = o;
       return resp;
     }
@@ -186,22 +231,28 @@ CoreResponse CoreEngine::handle(const CoreRequest& req, const Snapshot& snapshot
     if (req.method == "window.ensureVisible") {
       auto hwnd_s = get_str(req.params, "hwnd");
       auto vis = get_bool(req.params, "visible");
-      if (!hwnd_s || !vis) throw std::runtime_error("missing hwnd/visible");
+      if (!hwnd_s || !vis)
+        throw std::runtime_error("missing hwnd/visible");
       auto hwnd = parse_hwnd(*hwnd_s);
-      if (!hwnd) throw std::runtime_error("bad hwnd");
+      if (!hwnd)
+        throw std::runtime_error("bad hwnd");
       auto r = backend_->ensure_visible(*hwnd, *vis);
-      json::Object o; o["changed"] = r.changed;
+      json::Object o;
+      o["changed"] = r.changed;
       resp.result = o;
       return resp;
     }
 
     if (req.method == "window.ensureForeground") {
       auto hwnd_s = get_str(req.params, "hwnd");
-      if (!hwnd_s) throw std::runtime_error("missing hwnd");
+      if (!hwnd_s)
+        throw std::runtime_error("missing hwnd");
       auto hwnd = parse_hwnd(*hwnd_s);
-      if (!hwnd) throw std::runtime_error("bad hwnd");
+      if (!hwnd)
+        throw std::runtime_error("bad hwnd");
       auto r = backend_->ensure_foreground(*hwnd);
-      json::Object o; o["changed"] = r.changed;
+      json::Object o;
+      o["changed"] = r.changed;
       resp.result = o;
       return resp;
     }
@@ -211,32 +262,40 @@ CoreResponse CoreEngine::handle(const CoreRequest& req, const Snapshot& snapshot
       auto msg = get_num(req.params, "msg");
       auto wparam = get_num(req.params, "wparam");
       auto lparam = get_num(req.params, "lparam");
-      if (!hwnd_s || !msg) throw std::runtime_error("missing hwnd/msg");
+      if (!hwnd_s || !msg)
+        throw std::runtime_error("missing hwnd/msg");
       auto hwnd = parse_hwnd(*hwnd_s);
-      if (!hwnd) throw std::runtime_error("bad hwnd");
-      bool ok = backend_->post_message(*hwnd, (uint32_t)*msg, (uint64_t)(wparam.value_or(0)), (uint64_t)(lparam.value_or(0)));
-      json::Object o; o["sent"] = ok;
+      if (!hwnd)
+        throw std::runtime_error("bad hwnd");
+      bool ok = backend_->post_message(*hwnd, (uint32_t)*msg,
+                                       (uint64_t)(wparam.value_or(0)),
+                                       (uint64_t)(lparam.value_or(0)));
+      json::Object o;
+      o["sent"] = ok;
       resp.result = o;
       return resp;
     }
 
     if (req.method == "input.send") {
       auto data_b64 = get_str(req.params, "data_b64");
-      if (!data_b64) throw std::runtime_error("missing data_b64");
+      if (!data_b64)
+        throw std::runtime_error("missing data_b64");
       auto data = base64_decode(*data_b64);
       bool ok = backend_->send_input(data);
-      json::Object o; o["sent"] = ok;
+      json::Object o;
+      o["sent"] = ok;
       resp.result = o;
       return resp;
     }
 
-    // snapshot.capture/events.* are handled in daemon layer (session/scoped state)
+    // snapshot.capture/events.* are handled in daemon layer (session/scoped
+    // state)
     resp.ok = false;
     resp.error_code = "E_BAD_METHOD";
     resp.error_message = "method not implemented in core";
     return resp;
 
-  } catch (const std::exception& e) {
+  } catch (const std::exception &e) {
     resp.ok = false;
     resp.error_code = "E_BAD_REQUEST";
     resp.error_message = e.what();
@@ -246,14 +305,17 @@ CoreResponse CoreEngine::handle(const CoreRequest& req, const Snapshot& snapshot
 
 CoreRequest parse_request_json(std::string_view json_utf8) {
   auto v = json::parse(json_utf8);
-  if (!v.is_obj()) throw std::runtime_error("request must be object");
-  const auto& o = v.as_obj();
+  if (!v.is_obj())
+    throw std::runtime_error("request must be object");
+  const auto &o = v.as_obj();
 
   auto it_id = o.find("id");
-  auto it_m  = o.find("method");
-  auto it_p  = o.find("params");
-  if (it_id==o.end() || it_m==o.end() || it_p==o.end()) throw std::runtime_error("missing fields");
-  if (!it_id->second.is_str() || !it_m->second.is_str() || !it_p->second.is_obj())
+  auto it_m = o.find("method");
+  auto it_p = o.find("params");
+  if (it_id == o.end() || it_m == o.end() || it_p == o.end())
+    throw std::runtime_error("missing fields");
+  if (!it_id->second.is_str() || !it_m->second.is_str() ||
+      !it_p->second.is_obj())
     throw std::runtime_error("bad field types");
 
   CoreRequest r;
@@ -263,7 +325,7 @@ CoreRequest parse_request_json(std::string_view json_utf8) {
   return r;
 }
 
-std::string serialize_response_json(const CoreResponse& resp, bool canonical) {
+std::string serialize_response_json(const CoreResponse &resp, bool canonical) {
   (void)canonical;
   json::Value v = resp.to_json_obj(canonical);
   return json::dumps(v);

--- a/core/src/crypto.cpp
+++ b/core/src/crypto.cpp
@@ -1,12 +1,12 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
 #include <bcrypt.h>
-#include <vector>
-#include <string>
-#include <sstream>
 #include <fstream>
 #include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <windows.h>
 
 #include "wininspect/crypto.hpp"
 
@@ -16,222 +16,275 @@
 
 namespace wininspect::crypto {
 
-static std::vector<uint8_t> base64_decode(const std::string& in);
+static std::vector<uint8_t> base64_decode(const std::string &in);
 
 struct BCryptState {
-    BCRYPT_ALG_HANDLE hAlgECDH = nullptr;
-    BCRYPT_KEY_HANDLE hLocalKey = nullptr;
-    BCRYPT_ALG_HANDLE hAlgAES = nullptr;
-    BCRYPT_KEY_HANDLE hSessionKey = nullptr;
+  BCRYPT_ALG_HANDLE hAlgECDH = nullptr;
+  BCRYPT_KEY_HANDLE hLocalKey = nullptr;
+  BCRYPT_ALG_HANDLE hAlgAES = nullptr;
+  BCRYPT_KEY_HANDLE hSessionKey = nullptr;
 };
 
-CryptoSession::CryptoSession() {
-    hAlgAES_ = new BCryptState();
-}
+CryptoSession::CryptoSession() { hAlgAES_ = new BCryptState(); }
 
 CryptoSession::~CryptoSession() {
-    BCryptState* st = (BCryptState*)hAlgAES_;
-    if (st->hSessionKey) BCryptDestroyKey(st->hSessionKey);
-    if (st->hAlgAES) BCryptCloseAlgorithmProvider(st->hAlgAES, 0);
-    if (st->hLocalKey) BCryptDestroyKey(st->hLocalKey);
-    if (st->hAlgECDH) BCryptCloseAlgorithmProvider(st->hAlgECDH, 0);
-    delete st;
+  BCryptState *st = (BCryptState *)hAlgAES_;
+  if (st->hSessionKey)
+    BCryptDestroyKey(st->hSessionKey);
+  if (st->hAlgAES)
+    BCryptCloseAlgorithmProvider(st->hAlgAES, 0);
+  if (st->hLocalKey)
+    BCryptDestroyKey(st->hLocalKey);
+  if (st->hAlgECDH)
+    BCryptCloseAlgorithmProvider(st->hAlgECDH, 0);
+  delete st;
 }
 
 std::vector<uint8_t> CryptoSession::generate_local_key() {
-    BCryptState* st = (BCryptState*)hAlgAES_;
-    if (BCryptOpenAlgorithmProvider(&st->hAlgECDH, BCRYPT_ECDH_P256_ALGORITHM, nullptr, 0) != 0) return {};
-    if (BCryptGenerateKeyPair(st->hAlgECDH, &st->hLocalKey, 256, 0) != 0) return {};
-    if (BCryptFinalizeKeyPair(st->hLocalKey, 0) != 0) return {};
+  BCryptState *st = (BCryptState *)hAlgAES_;
+  if (BCryptOpenAlgorithmProvider(&st->hAlgECDH, BCRYPT_ECDH_P256_ALGORITHM,
+                                  nullptr, 0) != 0)
+    return {};
+  if (BCryptGenerateKeyPair(st->hAlgECDH, &st->hLocalKey, 256, 0) != 0)
+    return {};
+  if (BCryptFinalizeKeyPair(st->hLocalKey, 0) != 0)
+    return {};
 
-    ULONG cbBlob = 0;
-    BCryptExportKey(st->hLocalKey, nullptr, BCRYPT_ECCPUBLIC_BLOB, nullptr, 0, &cbBlob, 0);
-    std::vector<uint8_t> blob(cbBlob);
-    BCryptExportKey(st->hLocalKey, nullptr, BCRYPT_ECCPUBLIC_BLOB, blob.data(), cbBlob, &cbBlob, 0);
-    return blob;
+  ULONG cbBlob = 0;
+  BCryptExportKey(st->hLocalKey, nullptr, BCRYPT_ECCPUBLIC_BLOB, nullptr, 0,
+                  &cbBlob, 0);
+  std::vector<uint8_t> blob(cbBlob);
+  BCryptExportKey(st->hLocalKey, nullptr, BCRYPT_ECCPUBLIC_BLOB, blob.data(),
+                  cbBlob, &cbBlob, 0);
+  return blob;
 }
 
-bool CryptoSession::compute_shared_secret(const std::vector<uint8_t>& remote_pubkey) {
-    BCryptState* st = (BCryptState*)hAlgAES_;
-    BCRYPT_KEY_HANDLE hRemoteKey = nullptr;
-    if (BCryptImportKeyPair(st->hAlgECDH, nullptr, BCRYPT_ECCPUBLIC_BLOB, &hRemoteKey, (PUCHAR)remote_pubkey.data(), (ULONG)remote_pubkey.size(), 0) != 0) return false;
+bool CryptoSession::compute_shared_secret(
+    const std::vector<uint8_t> &remote_pubkey) {
+  BCryptState *st = (BCryptState *)hAlgAES_;
+  BCRYPT_KEY_HANDLE hRemoteKey = nullptr;
+  if (BCryptImportKeyPair(st->hAlgECDH, nullptr, BCRYPT_ECCPUBLIC_BLOB,
+                          &hRemoteKey, (PUCHAR)remote_pubkey.data(),
+                          (ULONG)remote_pubkey.size(), 0) != 0)
+    return false;
 
-    BCRYPT_SECRET_HANDLE hSecret = nullptr;
-    if (BCryptSecretAgreement(st->hLocalKey, hRemoteKey, &hSecret, 0) != 0) {
-        BCryptDestroyKey(hRemoteKey);
-        return false;
-    }
+  BCRYPT_SECRET_HANDLE hSecret = nullptr;
+  if (BCryptSecretAgreement(st->hLocalKey, hRemoteKey, &hSecret, 0) != 0) {
+    BCryptDestroyKey(hRemoteKey);
+    return false;
+  }
 
-    BCRYPT_BUFFER_DESC derDesc = { 0 };
-    BCRYPT_BUFFER derBuffers[1] = { 0 };
-    derDesc.cBuffers = 1;
-    derDesc.pBuffers = derBuffers;
-    derDesc.ulVersion = BCRYPTBUFFER_VERSION;
-    derBuffers[0].BufferType = KDF_HASH_ALGORITHM;
-    derBuffers[0].cbBuffer = (ULONG)((wcslen(BCRYPT_SHA256_ALGORITHM) + 1) * sizeof(wchar_t));
-    derBuffers[0].pvBuffer = (PVOID)BCRYPT_SHA256_ALGORITHM;
+  BCRYPT_BUFFER_DESC derDesc = {0};
+  BCRYPT_BUFFER derBuffers[1] = {0};
+  derDesc.cBuffers = 1;
+  derDesc.pBuffers = derBuffers;
+  derDesc.ulVersion = BCRYPTBUFFER_VERSION;
+  derBuffers[0].BufferType = KDF_HASH_ALGORITHM;
+  derBuffers[0].cbBuffer =
+      (ULONG)((wcslen(BCRYPT_SHA256_ALGORITHM) + 1) * sizeof(wchar_t));
+  derBuffers[0].pvBuffer = (PVOID)BCRYPT_SHA256_ALGORITHM;
 
-    uint8_t derived[32];
-    ULONG cbDerived = 0;
-    if (BCryptDeriveKey(hSecret, BCRYPT_KDF_HASH, &derDesc, derived, 32, &cbDerived, 0) != 0) {
-        BCryptDestroySecret(hSecret);
-        BCryptDestroyKey(hRemoteKey);
-        return false;
-    }
-
+  uint8_t derived[32];
+  ULONG cbDerived = 0;
+  if (BCryptDeriveKey(hSecret, BCRYPT_KDF_HASH, &derDesc, derived, 32,
+                      &cbDerived, 0) != 0) {
     BCryptDestroySecret(hSecret);
     BCryptDestroyKey(hRemoteKey);
+    return false;
+  }
 
-    if (BCryptOpenAlgorithmProvider(&st->hAlgAES, BCRYPT_AES_ALGORITHM, nullptr, 0) != 0) return false;
-    if (BCryptSetProperty(st->hAlgAES, BCRYPT_CHAINING_MODE, (PUCHAR)BCRYPT_CHAIN_MODE_GCM, sizeof(BCRYPT_CHAIN_MODE_GCM), 0) != 0) return false;
+  BCryptDestroySecret(hSecret);
+  BCryptDestroyKey(hRemoteKey);
 
-    if (BCryptGenerateSymmetricKey(st->hAlgAES, &st->hSessionKey, nullptr, 0, derived, 32, 0) != 0) return false;
+  if (BCryptOpenAlgorithmProvider(&st->hAlgAES, BCRYPT_AES_ALGORITHM, nullptr,
+                                  0) != 0)
+    return false;
+  if (BCryptSetProperty(st->hAlgAES, BCRYPT_CHAINING_MODE,
+                        (PUCHAR)BCRYPT_CHAIN_MODE_GCM,
+                        sizeof(BCRYPT_CHAIN_MODE_GCM), 0) != 0)
+    return false;
 
-    initialized_ = true;
-    return true;
+  if (BCryptGenerateSymmetricKey(st->hAlgAES, &st->hSessionKey, nullptr, 0,
+                                 derived, 32, 0) != 0)
+    return false;
+
+  initialized_ = true;
+  return true;
 }
 
-std::vector<uint8_t> CryptoSession::encrypt(const std::string& plaintext) {
-    if (!initialized_) return {};
-    BCryptState* st = (BCryptState*)hAlgAES_;
+std::vector<uint8_t> CryptoSession::encrypt(const std::string &plaintext) {
+  if (!initialized_)
+    return {};
+  BCryptState *st = (BCryptState *)hAlgAES_;
 
-    BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO authInfo;
-    BCRYPT_INIT_AUTH_MODE_INFO(authInfo);
+  BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO authInfo;
+  BCRYPT_INIT_AUTH_MODE_INFO(authInfo);
 
-    uint8_t nonce[12] = { 0 };
-    memcpy(nonce, &nonce_counter_, sizeof(nonce_counter_));
-    nonce_counter_++;
+  uint8_t nonce[12] = {0};
+  memcpy(nonce, &nonce_counter_, sizeof(nonce_counter_));
+  nonce_counter_++;
 
-    uint8_t tag[16];
-    authInfo.pbNonce = nonce;
-    authInfo.cbNonce = 12;
-    authInfo.pbTag = tag;
-    authInfo.cbTag = 16;
+  uint8_t tag[16];
+  authInfo.pbNonce = nonce;
+  authInfo.cbNonce = 12;
+  authInfo.pbTag = tag;
+  authInfo.cbTag = 16;
 
-    ULONG cbCipher = 0;
-    BCryptEncrypt(st->hSessionKey, (PUCHAR)plaintext.data(), (ULONG)plaintext.size(), &authInfo, nullptr, 0, nullptr, 0, &cbCipher, 0);
-    
-    std::vector<uint8_t> out(12 + 16 + cbCipher);
-    memcpy(out.data(), nonce, 12);
-    memcpy(out.data() + 12, tag, 16);
-    
-    BCryptEncrypt(st->hSessionKey, (PUCHAR)plaintext.data(), (ULONG)plaintext.size(), &authInfo, nullptr, 0, out.data() + 28, cbCipher, &cbCipher, 0);
-    return out;
+  ULONG cbCipher = 0;
+  BCryptEncrypt(st->hSessionKey, (PUCHAR)plaintext.data(),
+                (ULONG)plaintext.size(), &authInfo, nullptr, 0, nullptr, 0,
+                &cbCipher, 0);
+
+  std::vector<uint8_t> out(12 + 16 + cbCipher);
+  memcpy(out.data(), nonce, 12);
+  memcpy(out.data() + 12, tag, 16);
+
+  BCryptEncrypt(st->hSessionKey, (PUCHAR)plaintext.data(),
+                (ULONG)plaintext.size(), &authInfo, nullptr, 0, out.data() + 28,
+                cbCipher, &cbCipher, 0);
+  return out;
 }
 
-std::string CryptoSession::decrypt(const std::vector<uint8_t>& ciphertext) {
-    if (!initialized_ || ciphertext.size() < 28) return "";
-    BCryptState* st = (BCryptState*)hAlgAES_;
+std::string CryptoSession::decrypt(const std::vector<uint8_t> &ciphertext) {
+  if (!initialized_ || ciphertext.size() < 28)
+    return "";
+  BCryptState *st = (BCryptState *)hAlgAES_;
 
-    BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO authInfo;
-    BCRYPT_INIT_AUTH_MODE_INFO(authInfo);
+  BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO authInfo;
+  BCRYPT_INIT_AUTH_MODE_INFO(authInfo);
 
-    authInfo.pbNonce = (PUCHAR)ciphertext.data();
-    authInfo.cbNonce = 12;
-    authInfo.pbTag = (PUCHAR)ciphertext.data() + 12;
-    authInfo.cbTag = 16;
+  authInfo.pbNonce = (PUCHAR)ciphertext.data();
+  authInfo.cbNonce = 12;
+  authInfo.pbTag = (PUCHAR)ciphertext.data() + 12;
+  authInfo.cbTag = 16;
 
-    ULONG cbPlain = 0;
-    ULONG cbCipher = (ULONG)ciphertext.size() - 28;
-    if (BCryptDecrypt(st->hSessionKey, (PUCHAR)ciphertext.data() + 28, cbCipher, &authInfo, nullptr, 0, nullptr, 0, &cbPlain, 0) != 0) return "";
+  ULONG cbPlain = 0;
+  ULONG cbCipher = (ULONG)ciphertext.size() - 28;
+  if (BCryptDecrypt(st->hSessionKey, (PUCHAR)ciphertext.data() + 28, cbCipher,
+                    &authInfo, nullptr, 0, nullptr, 0, &cbPlain, 0) != 0)
+    return "";
 
-    std::string out;
-    out.resize(cbPlain);
-    if (BCryptDecrypt(st->hSessionKey, (PUCHAR)ciphertext.data() + 28, cbCipher, &authInfo, nullptr, 0, (PUCHAR)out.data(), cbPlain, &cbPlain, 0) != 0) return "";
-    
-    return out;
+  std::string out;
+  out.resize(cbPlain);
+  if (BCryptDecrypt(st->hSessionKey, (PUCHAR)ciphertext.data() + 28, cbCipher,
+                    &authInfo, nullptr, 0, (PUCHAR)out.data(), cbPlain,
+                    &cbPlain, 0) != 0)
+    return "";
+
+  return out;
 }
 
-static std::vector<uint8_t> base64_decode(const std::string& in) {
-    static const std::string b64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    std::vector<uint8_t> out;
-    std::vector<int> T(256, -1);
-    for (int i = 0; i < 64; i++) T[b64[i]] = i;
-    int val = 0, valb = -8;
-    for (char c : in) {
-        if (T[c] == -1) break;
-        val = (val << 6) + T[c];
-        valb += 6;
-        if (valb >= 0) {
-            out.push_back(uint8_t((val >> valb) & 0xFF));
-            valb -= 8;
-        }
+static std::vector<uint8_t> base64_decode(const std::string &in) {
+  static const std::string b64 =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  std::vector<uint8_t> out;
+  std::vector<int> T(256, -1);
+  for (int i = 0; i < 64; i++)
+    T[b64[i]] = i;
+  int val = 0, valb = -8;
+  for (char c : in) {
+    if (T[c] == -1)
+      break;
+    val = (val << 6) + T[c];
+    valb += 6;
+    if (valb >= 0) {
+      out.push_back(uint8_t((val >> valb) & 0xFF));
+      valb -= 8;
     }
-    return out;
+  }
+  return out;
 }
 
-static std::vector<uint8_t> parse_ssh_pubkey(const std::string& line) {
-    std::stringstream ss(line);
-    std::string type, b64;
-    ss >> type >> b64;
-    if (type != "ssh-ed25519") return {};
-    auto decoded = base64_decode(b64);
-    // SSH Ed25519 pubkey format: [len][type][len][pubkey]
-    // For Ed25519, the last 32 bytes are the raw key.
-    if (decoded.size() < 32) return {};
-    return std::vector<uint8_t>(decoded.end() - 32, decoded.end());
+static std::vector<uint8_t> parse_ssh_pubkey(const std::string &line) {
+  std::stringstream ss(line);
+  std::string type, b64;
+  ss >> type >> b64;
+  if (type != "ssh-ed25519")
+    return {};
+  auto decoded = base64_decode(b64);
+  // SSH Ed25519 pubkey format: [len][type][len][pubkey]
+  // For Ed25519, the last 32 bytes are the raw key.
+  if (decoded.size() < 32)
+    return {};
+  return std::vector<uint8_t>(decoded.end() - 32, decoded.end());
 }
 
-bool verify_ssh_sig(const std::vector<uint8_t>& message, const std::string& sig_b64, const std::string& pubkey_line) {
-    auto raw_pubkey = parse_ssh_pubkey(pubkey_line);
-    if (raw_pubkey.empty()) return false;
+bool verify_ssh_sig(const std::vector<uint8_t> &message,
+                    const std::string &sig_b64,
+                    const std::string &pubkey_line) {
+  auto raw_pubkey = parse_ssh_pubkey(pubkey_line);
+  if (raw_pubkey.empty())
+    return false;
 
-    // Decode signature blob. 
-    // In a full implementation, we'd parse the SSHSIG wrapper.
-    // For brevity, we assume the signature is the raw 64-byte Ed25519 signature.
-    auto raw_sig = base64_decode(sig_b64);
-    if (raw_sig.size() < 64) return false;
+  // Decode signature blob.
+  // In a full implementation, we'd parse the SSHSIG wrapper.
+  // For brevity, we assume the signature is the raw 64-byte Ed25519 signature.
+  auto raw_sig = base64_decode(sig_b64);
+  if (raw_sig.size() < 64)
+    return false;
 
-    BCRYPT_ALG_HANDLE hAlg = nullptr;
-    if (BCryptOpenAlgorithmProvider(&hAlg, L"ECC_ED25519", nullptr, 0) != 0) return false;
+  BCRYPT_ALG_HANDLE hAlg = nullptr;
+  if (BCryptOpenAlgorithmProvider(&hAlg, L"ECC_ED25519", nullptr, 0) != 0)
+    return false;
 
-    BCRYPT_KEY_HANDLE hKey = nullptr;
-    // For BCrypt, we need to wrap the raw 32-byte pubkey in a BCRYPT_ECCKEY_BLOB
-    std::vector<uint8_t> blob(sizeof(BCRYPT_ECCKEY_BLOB) + 32);
-    PBCRYPT_ECCKEY_BLOB pBlob = (PBCRYPT_ECCKEY_BLOB)blob.data();
-    pBlob->dwMagic = BCRYPT_ECD_PUBLIC_GENERIC_MAGIC;
-    pBlob->cbKey = 32;
-    memcpy(blob.data() + sizeof(BCRYPT_ECCKEY_BLOB), raw_pubkey.data(), 32);
+  BCRYPT_KEY_HANDLE hKey = nullptr;
+  // For BCrypt, we need to wrap the raw 32-byte pubkey in a BCRYPT_ECCKEY_BLOB
+  std::vector<uint8_t> blob(sizeof(BCRYPT_ECCKEY_BLOB) + 32);
+  PBCRYPT_ECCKEY_BLOB pBlob = (PBCRYPT_ECCKEY_BLOB)blob.data();
+  pBlob->dwMagic = BCRYPT_ECD_PUBLIC_GENERIC_MAGIC;
+  pBlob->cbKey = 32;
+  memcpy(blob.data() + sizeof(BCRYPT_ECCKEY_BLOB), raw_pubkey.data(), 32);
 
-    bool ok = false;
-    if (BCryptImportKeyPair(hAlg, nullptr, BCRYPT_ECCPUBLIC_BLOB, &hKey, blob.data(), (ULONG)blob.size(), 0) == 0) {
-        if (BCryptVerifySignature(hKey, nullptr, (PUCHAR)message.data(), (ULONG)message.size(), (PUCHAR)raw_sig.data(), 64, 0) == 0) {
-            ok = true;
-        }
-        BCryptDestroyKey(hKey);
+  bool ok = false;
+  if (BCryptImportKeyPair(hAlg, nullptr, BCRYPT_ECCPUBLIC_BLOB, &hKey,
+                          blob.data(), (ULONG)blob.size(), 0) == 0) {
+    if (BCryptVerifySignature(hKey, nullptr, (PUCHAR)message.data(),
+                              (ULONG)message.size(), (PUCHAR)raw_sig.data(), 64,
+                              0) == 0) {
+      ok = true;
     }
+    BCryptDestroyKey(hKey);
+  }
 
-    BCryptCloseAlgorithmProvider(hAlg, 0);
-    return ok;
+  BCryptCloseAlgorithmProvider(hAlg, 0);
+  return ok;
 }
 
-std::string sign_ssh_msg(const std::vector<uint8_t>& message, const std::string& private_key_path) {
-    // Reading OpenSSH private keys requires a specialized parser (PEM/Base64 + KDF).
-    // In a proven production environment, you would use a library like 'libssh2' or 'mbedtls' 
-    // to parse the key file. 
-    // 
-    // Since we must avoid external binaries and complex dependencies, we focus on 
-    // the system-provided BCrypt logic for the actual signing operation.
-    return "SSHSIG_STUB_REPLACE_WITH_REAL_SIGNING";
+std::string sign_ssh_msg(const std::vector<uint8_t> &message,
+                         const std::string &private_key_path) {
+  // Reading OpenSSH private keys requires a specialized parser (PEM/Base64 +
+  // KDF). In a proven production environment, you would use a library like
+  // 'libssh2' or 'mbedtls' to parse the key file.
+  //
+  // Since we must avoid external binaries and complex dependencies, we focus on
+  // the system-provided BCrypt logic for the actual signing operation.
+  return "SSHSIG_STUB_REPLACE_WITH_REAL_SIGNING";
 }
 
 } // namespace wininspect::crypto
 #else
 // Non-windows fallback
 #include "wininspect/crypto.hpp"
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace wininspect::crypto {
 
 CryptoSession::CryptoSession() {}
 CryptoSession::~CryptoSession() {}
 std::vector<uint8_t> CryptoSession::generate_local_key() { return {}; }
-bool CryptoSession::compute_shared_secret(const std::vector<uint8_t>&) { return false; }
-std::vector<uint8_t> CryptoSession::encrypt(const std::string&) { return {}; }
-std::string CryptoSession::decrypt(const std::vector<uint8_t>&) { return ""; }
-
-bool verify_ssh_sig(const std::vector<uint8_t>&, const std::string&, const std::string&) { return false; }
-std::string sign_ssh_msg(const std::vector<uint8_t>&, const std::string&) { return ""; }
+bool CryptoSession::compute_shared_secret(const std::vector<uint8_t> &) {
+  return false;
 }
+std::vector<uint8_t> CryptoSession::encrypt(const std::string &) { return {}; }
+std::string CryptoSession::decrypt(const std::vector<uint8_t> &) { return ""; }
+
+bool verify_ssh_sig(const std::vector<uint8_t> &, const std::string &,
+                    const std::string &) {
+  return false;
+}
+std::string sign_ssh_msg(const std::vector<uint8_t> &, const std::string &) {
+  return "";
+}
+} // namespace wininspect::crypto
 #endif

--- a/core/src/crypto_windows.cpp
+++ b/core/src/crypto_windows.cpp
@@ -1,11 +1,11 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
 #include <bcrypt.h>
-#include <vector>
-#include <string>
-#include <sstream>
 #include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <windows.h>
 
 #include "wininspect/crypto.hpp"
 
@@ -13,51 +13,64 @@
 
 namespace wininspect::crypto {
 
-static std::vector<uint8_t> base64_decode(const std::string& in) {
-    static const std::string b64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    std::vector<uint8_t> out;
-    std::vector<int> T(256, -1);
-    for (int i = 0; i < 64; i++) T[b64[i]] = i;
-    int val = 0, valb = -8;
-    for (char c : in) {
-        if (T[c] == -1) break;
-        val = (val << 6) + T[c];
-        valb += 6;
-        if (valb >= 0) {
-            out.push_back(uint8_t((val >> valb) & 0xFF));
-            valb -= 8;
-        }
+static std::vector<uint8_t> base64_decode(const std::string &in) {
+  static const std::string b64 =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  std::vector<uint8_t> out;
+  std::vector<int> T(256, -1);
+  for (int i = 0; i < 64; i++)
+    T[b64[i]] = i;
+  int val = 0, valb = -8;
+  for (char c : in) {
+    if (T[c] == -1)
+      break;
+    val = (val << 6) + T[c];
+    valb += 6;
+    if (valb >= 0) {
+      out.push_back(uint8_t((val >> valb) & 0xFF));
+      valb -= 8;
     }
-    return out;
+  }
+  return out;
 }
 
 // Minimal SSH public key parser (ssh-ed25519 <key_b64> ...)
-static std::vector<uint8_t> parse_ssh_pubkey(const std::string& line) {
-    std::stringstream ss(line);
-    std::string type, b64;
-    ss >> type >> b64;
-    if (type != "ssh-ed25519") return {};
-    auto decoded = base64_decode(b64);
-    // Format: 4-byte len ("ssh-ed25519") + "ssh-ed25519" + 4-byte len (32) + 32-byte key
-    if (decoded.size() < 11 + 32 + 8) return {};
-    return std::vector<uint8_t>(decoded.end() - 32, decoded.end());
+static std::vector<uint8_t> parse_ssh_pubkey(const std::string &line) {
+  std::stringstream ss(line);
+  std::string type, b64;
+  ss >> type >> b64;
+  if (type != "ssh-ed25519")
+    return {};
+  auto decoded = base64_decode(b64);
+  // Format: 4-byte len ("ssh-ed25519") + "ssh-ed25519" + 4-byte len (32) +
+  // 32-byte key
+  if (decoded.size() < 11 + 32 + 8)
+    return {};
+  return std::vector<uint8_t>(decoded.end() - 32, decoded.end());
 }
 
-bool verify_ssh_sig(const std::vector<uint8_t>& message, const std::string& sig_b64, const std::string& pubkey_line) {
-    auto pubkey = parse_ssh_pubkey(pubkey_line);
-    if (pubkey.empty()) return false;
+bool verify_ssh_sig(const std::vector<uint8_t> &message,
+                    const std::string &sig_b64,
+                    const std::string &pubkey_line) {
+  auto pubkey = parse_ssh_pubkey(pubkey_line);
+  if (pubkey.empty())
+    return false;
 
-    BCRYPT_ALG_HANDLE hAlg = nullptr;
-    if (BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_ECDSA_P256_ALGORITHM, nullptr, 0) != 0) return false;
-    // Note: Ed25519 is supported in newer Windows 10 versions via BCRYPT_ED25519_ALGORITHM.
-    // If not available, we'd fallback to a bundled library.
-    
-    // For this implementation, we assume a modern Windows environment as requested.
-    BCryptCloseAlgorithmProvider(hAlg, 0);
-    
-    // In a real implementation without ssh-keygen, we would use a small ed25519 library 
-    // to ensure compatibility across all versions and Linux.
-    return true; // Placeholder for logic
+  BCRYPT_ALG_HANDLE hAlg = nullptr;
+  if (BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_ECDSA_P256_ALGORITHM, nullptr,
+                                  0) != 0)
+    return false;
+  // Note: Ed25519 is supported in newer Windows 10 versions via
+  // BCRYPT_ED25519_ALGORITHM. If not available, we'd fallback to a bundled
+  // library.
+
+  // For this implementation, we assume a modern Windows environment as
+  // requested.
+  BCryptCloseAlgorithmProvider(hAlg, 0);
+
+  // In a real implementation without ssh-keygen, we would use a small ed25519
+  // library to ensure compatibility across all versions and Linux.
+  return true; // Placeholder for logic
 }
 
 } // namespace wininspect::crypto

--- a/core/src/win32_backend.cpp
+++ b/core/src/win32_backend.cpp
@@ -2,21 +2,28 @@
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
 #include <psapi.h>
-#include <vector>
 #include <string>
+#include <vector>
+#include <windows.h>
 
 namespace wininspect {
 
-static hwnd_u64 to_u64(HWND h) { return static_cast<hwnd_u64>(reinterpret_cast<std::uintptr_t>(h)); }
-static HWND from_u64(hwnd_u64 h) { return reinterpret_cast<HWND>(static_cast<std::uintptr_t>(h)); }
+static hwnd_u64 to_u64(HWND h) {
+  return static_cast<hwnd_u64>(reinterpret_cast<std::uintptr_t>(h));
+}
+static HWND from_u64(hwnd_u64 h) {
+  return reinterpret_cast<HWND>(static_cast<std::uintptr_t>(h));
+}
 
-static std::string w2u8(const std::wstring& ws) {
-  if (ws.empty()) return {};
-  int len = WideCharToMultiByte(CP_UTF8, 0, ws.c_str(), (int)ws.size(), nullptr, 0, nullptr, nullptr);
+static std::string w2u8(const std::wstring &ws) {
+  if (ws.empty())
+    return {};
+  int len = WideCharToMultiByte(CP_UTF8, 0, ws.c_str(), (int)ws.size(), nullptr,
+                                0, nullptr, nullptr);
   std::string out(len, '\0');
-  WideCharToMultiByte(CP_UTF8, 0, ws.c_str(), (int)ws.size(), out.data(), len, nullptr, nullptr);
+  WideCharToMultiByte(CP_UTF8, 0, ws.c_str(), (int)ws.size(), out.data(), len,
+                      nullptr, nullptr);
   return out;
 }
 
@@ -38,7 +45,8 @@ static std::wstring get_class_name_w(HWND hwnd) {
 static std::string try_process_image_path(DWORD pid) {
   std::string out;
   HANDLE h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
-  if (!h) return out;
+  if (!h)
+    return out;
   wchar_t buf[32768];
   DWORD sz = (DWORD)(sizeof(buf) / sizeof(buf[0]));
   if (QueryFullProcessImageNameW(h, 0, buf, &sz)) {
@@ -50,36 +58,46 @@ static std::string try_process_image_path(DWORD pid) {
 
 Snapshot Win32Backend::capture_snapshot() {
   Snapshot s;
-  EnumWindows([](HWND h, LPARAM lp) -> BOOL {
-    auto* vec = reinterpret_cast<std::vector<hwnd_u64>*>(lp);
-    vec->push_back(to_u64(h));
-    return TRUE;
-  }, reinterpret_cast<LPARAM>(&s.top));
+  EnumWindows(
+      [](HWND h, LPARAM lp) -> BOOL {
+        auto *vec = reinterpret_cast<std::vector<hwnd_u64> *>(lp);
+        vec->push_back(to_u64(h));
+        return TRUE;
+      },
+      reinterpret_cast<LPARAM>(&s.top));
   return s;
 }
 
-std::vector<hwnd_u64> Win32Backend::list_top(const Snapshot& s) { return s.top; }
+std::vector<hwnd_u64> Win32Backend::list_top(const Snapshot &s) {
+  return s.top;
+}
 
-std::vector<hwnd_u64> Win32Backend::list_children(const Snapshot&, hwnd_u64 parent) {
+std::vector<hwnd_u64> Win32Backend::list_children(const Snapshot &,
+                                                  hwnd_u64 parent) {
   std::vector<hwnd_u64> out;
-  EnumChildWindows(from_u64(parent), [](HWND h, LPARAM lp) -> BOOL {
-    auto* vec = reinterpret_cast<std::vector<hwnd_u64>*>(lp);
-    vec->push_back(to_u64(h));
-    return TRUE;
-  }, reinterpret_cast<LPARAM>(&out));
+  EnumChildWindows(
+      from_u64(parent),
+      [](HWND h, LPARAM lp) -> BOOL {
+        auto *vec = reinterpret_cast<std::vector<hwnd_u64> *>(lp);
+        vec->push_back(to_u64(h));
+        return TRUE;
+      },
+      reinterpret_cast<LPARAM>(&out));
   return out;
 }
 
-std::optional<WindowInfo> Win32Backend::get_info(const Snapshot&, hwnd_u64 hwnd_u) {
+std::optional<WindowInfo> Win32Backend::get_info(const Snapshot &,
+                                                 hwnd_u64 hwnd_u) {
   HWND hwnd = from_u64(hwnd_u);
-  if (!IsWindow(hwnd)) return std::nullopt;
+  if (!IsWindow(hwnd))
+    return std::nullopt;
 
   WindowInfo wi{};
   wi.hwnd = hwnd_u;
   wi.parent = to_u64(GetParent(hwnd));
-  wi.owner  = to_u64(GetWindow(hwnd, GW_OWNER));
+  wi.owner = to_u64(GetWindow(hwnd, GW_OWNER));
   wi.class_name = w2u8(get_class_name_w(hwnd));
-  wi.title      = w2u8(get_window_text_w(hwnd));
+  wi.title = w2u8(get_window_text_w(hwnd));
 
   RECT r{};
   GetWindowRect(hwnd, &r);
@@ -89,7 +107,7 @@ std::optional<WindowInfo> Win32Backend::get_info(const Snapshot&, hwnd_u64 hwnd_
   GetClientRect(hwnd, &cr);
   wi.client_rect = {cr.left, cr.top, cr.right, cr.bottom};
 
-  DWORD pid=0;
+  DWORD pid = 0;
   wi.tid = GetWindowThreadProcessId(hwnd, &pid);
   wi.pid = pid;
 
@@ -100,91 +118,122 @@ std::optional<WindowInfo> Win32Backend::get_info(const Snapshot&, hwnd_u64 hwnd_
 
   wi.visible = IsWindowVisible(hwnd) != FALSE;
   wi.enabled = IsWindowEnabled(hwnd) != FALSE;
-  wi.iconic  = IsIconic(hwnd) != FALSE;
-  wi.zoomed  = IsZoomed(hwnd) != FALSE;
+  wi.iconic = IsIconic(hwnd) != FALSE;
+  wi.zoomed = IsZoomed(hwnd) != FALSE;
 
   wi.process_image = try_process_image_path(pid);
   return wi;
 }
 
-std::optional<hwnd_u64> Win32Backend::pick_at_point(const Snapshot&, int x, int y, PickFlags flags) {
-  POINT pt{x,y};
+std::optional<hwnd_u64> Win32Backend::pick_at_point(const Snapshot &, int x,
+                                                    int y, PickFlags flags) {
+  POINT pt{x, y};
   HWND h = WindowFromPoint(pt);
-  if (!h) return std::nullopt;
+  if (!h)
+    return std::nullopt;
 
   if (flags.prefer_child) {
-    HWND child = ChildWindowFromPointEx(h, pt, flags.ignore_transparent ? CWP_SKIPTRANSPARENT : 0);
-    if (child) h = child;
+    HWND child = ChildWindowFromPointEx(
+        h, pt, flags.ignore_transparent ? CWP_SKIPTRANSPARENT : 0);
+    if (child)
+      h = child;
   }
   return to_u64(h);
 }
 
 EnsureResult Win32Backend::ensure_visible(hwnd_u64 hwnd, bool visible) {
   HWND h = from_u64(hwnd);
-  if (!IsWindow(h)) return {false};
+  if (!IsWindow(h))
+    return {false};
   bool cur = IsWindowVisible(h) != FALSE;
-  if (cur == visible) return {false};
+  if (cur == visible)
+    return {false};
   ShowWindow(h, visible ? SW_SHOW : SW_HIDE);
   return {true};
 }
 
 EnsureResult Win32Backend::ensure_foreground(hwnd_u64 hwnd) {
   HWND h = from_u64(hwnd);
-  if (!IsWindow(h)) return {false};
+  if (!IsWindow(h))
+    return {false};
   HWND fg = GetForegroundWindow();
-  if (fg == h) return {false};
+  if (fg == h)
+    return {false};
   SetForegroundWindow(h);
   return {true};
 }
 
-bool Win32Backend::post_message(hwnd_u64 hwnd, uint32_t msg, uint64_t wparam, uint64_t lparam) {
+bool Win32Backend::post_message(hwnd_u64 hwnd, uint32_t msg, uint64_t wparam,
+                                uint64_t lparam) {
   HWND h = from_u64(hwnd);
-  if (!IsWindow(h)) return false;
+  if (!IsWindow(h))
+    return false;
   return PostMessageW(h, msg, (WPARAM)wparam, (LPARAM)lparam) != FALSE;
 }
 
-bool Win32Backend::send_input(const std::vector<uint8_t>& raw_input_data) {
-  if (raw_input_data.empty()) return false;
+bool Win32Backend::send_input(const std::vector<uint8_t> &raw_input_data) {
+  if (raw_input_data.empty())
+    return false;
   // Assumes raw_input_data is a tightly packed array of INPUT structures
-  if (raw_input_data.size() % sizeof(INPUT) != 0) return false;
+  if (raw_input_data.size() % sizeof(INPUT) != 0)
+    return false;
   UINT count = (UINT)(raw_input_data.size() / sizeof(INPUT));
-  const INPUT* pInputs = reinterpret_cast<const INPUT*>(raw_input_data.data());
-  return SendInput(count, const_cast<INPUT*>(pInputs), sizeof(INPUT)) == count;
+  const INPUT *pInputs = reinterpret_cast<const INPUT *>(raw_input_data.data());
+  return SendInput(count, const_cast<INPUT *>(pInputs), sizeof(INPUT)) == count;
 }
 
 static std::vector<hwnd_u64> sorted(std::vector<hwnd_u64> v) {
-    std::sort(v.begin(), v.end());
-    return v;
+  std::sort(v.begin(), v.end());
+  return v;
 }
 
-std::vector<Event> Win32Backend::poll_events(const Snapshot& old_snap, const Snapshot& new_snap) {
-    std::vector<Event> out;
-    auto o = sorted(old_snap.top);
-    auto n = sorted(new_snap.top);
+std::vector<Event> Win32Backend::poll_events(const Snapshot &old_snap,
+                                             const Snapshot &new_snap) {
+  std::vector<Event> out;
+  auto o = sorted(old_snap.top);
+  auto n = sorted(new_snap.top);
 
-    std::vector<hwnd_u64> created;
-    std::set_difference(n.begin(), n.end(), o.begin(), o.end(), std::back_inserter(created));
-    for (auto h : created) out.push_back({"window.created", h, ""});
+  std::vector<hwnd_u64> created;
+  std::set_difference(n.begin(), n.end(), o.begin(), o.end(),
+                      std::back_inserter(created));
+  for (auto h : created)
+    out.push_back({"window.created", h, ""});
 
-    std::vector<hwnd_u64> destroyed;
-    std::set_difference(o.begin(), o.end(), n.begin(), n.end(), std::back_inserter(destroyed));
-    for (auto h : destroyed) out.push_back({"window.destroyed", h, ""});
+  std::vector<hwnd_u64> destroyed;
+  std::set_difference(o.begin(), o.end(), n.begin(), n.end(),
+                      std::back_inserter(destroyed));
+  for (auto h : destroyed)
+    out.push_back({"window.destroyed", h, ""});
 
-    return out;
+  return out;
 }
 
 } // namespace wininspect
 #else
 namespace wininspect {
 Snapshot Win32Backend::capture_snapshot() { return {}; }
-std::vector<hwnd_u64> Win32Backend::list_top(const Snapshot& s){ return s.top; }
-std::vector<hwnd_u64> Win32Backend::list_children(const Snapshot&, hwnd_u64){ return {}; }
-std::optional<WindowInfo> Win32Backend::get_info(const Snapshot&, hwnd_u64){ return std::nullopt; }
-std::optional<hwnd_u64> Win32Backend::pick_at_point(const Snapshot&, int,int,PickFlags){ return std::nullopt; }
-EnsureResult Win32Backend::ensure_visible(hwnd_u64, bool){ return {false}; }
-EnsureResult Win32Backend::ensure_foreground(hwnd_u64){ return {false}; }
-bool Win32Backend::post_message(hwnd_u64, uint32_t, uint64_t, uint64_t){ return false; }
-bool Win32Backend::send_input(const std::vector<uint8_t>&){ return false; }
-std::vector<Event> Win32Backend::poll_events(const Snapshot&, const Snapshot&){ return {}; }
+std::vector<hwnd_u64> Win32Backend::list_top(const Snapshot &s) {
+  return s.top;
 }
+std::vector<hwnd_u64> Win32Backend::list_children(const Snapshot &, hwnd_u64) {
+  return {};
+}
+std::optional<WindowInfo> Win32Backend::get_info(const Snapshot &, hwnd_u64) {
+  return std::nullopt;
+}
+std::optional<hwnd_u64> Win32Backend::pick_at_point(const Snapshot &, int, int,
+                                                    PickFlags) {
+  return std::nullopt;
+}
+EnsureResult Win32Backend::ensure_visible(hwnd_u64, bool) { return {false}; }
+EnsureResult Win32Backend::ensure_foreground(hwnd_u64) { return {false}; }
+bool Win32Backend::post_message(hwnd_u64, uint32_t, uint64_t, uint64_t) {
+  return false;
+}
+bool Win32Backend::send_input(const std::vector<uint8_t> &) { return false; }
+std::vector<Event> Win32Backend::poll_events(const Snapshot &,
+                                             const Snapshot &) {
+  return {};
+}
+} // namespace wininspect
 #endif

--- a/core/tests/test_core_idempotence.cpp
+++ b/core/tests/test_core_idempotence.cpp
@@ -6,8 +6,8 @@ using namespace wininspect;
 
 DOCTEST_TEST_CASE("ensureVisible is idempotent on FakeBackend") {
   FakeBackend fb({
-    {1,0,0,"A","C1",true},
-    {2,0,0,"B","C2",false},
+      {1, 0, 0, "A", "C1", true},
+      {2, 0, 0, "B", "C2", false},
   });
 
   Snapshot s = fb.capture_snapshot();

--- a/core/tests/test_crypto.cpp
+++ b/core/tests/test_crypto.cpp
@@ -5,27 +5,27 @@
 using namespace wininspect::crypto;
 
 DOCTEST_TEST_CASE("CryptoSession handshake and encryption") {
-    CryptoSession server;
-    CryptoSession client;
+  CryptoSession server;
+  CryptoSession client;
 
-    // 1. Generate keys
-    auto server_pub = server.generate_local_key();
-    auto client_pub = client.generate_local_key();
+  // 1. Generate keys
+  auto server_pub = server.generate_local_key();
+  auto client_pub = client.generate_local_key();
 
-    DOCTEST_REQUIRE(!server_pub.empty());
-    DOCTEST_REQUIRE(!client_pub.empty());
+  DOCTEST_REQUIRE(!server_pub.empty());
+  DOCTEST_REQUIRE(!client_pub.empty());
 
-    // 2. Exchange and compute secret
-    DOCTEST_REQUIRE(server.compute_shared_secret(client_pub));
-    DOCTEST_REQUIRE(client.compute_shared_secret(server_pub));
+  // 2. Exchange and compute secret
+  DOCTEST_REQUIRE(server.compute_shared_secret(client_pub));
+  DOCTEST_REQUIRE(client.compute_shared_secret(server_pub));
 
-    // 3. Encrypt/Decrypt roundtrip
-    std::string message = "Secret Window Title";
-    auto encrypted = client.encrypt(message);
-    DOCTEST_REQUIRE(!encrypted.empty());
-    DOCTEST_REQUIRE(encrypted.size() > message.size());
+  // 3. Encrypt/Decrypt roundtrip
+  std::string message = "Secret Window Title";
+  auto encrypted = client.encrypt(message);
+  DOCTEST_REQUIRE(!encrypted.empty());
+  DOCTEST_REQUIRE(encrypted.size() > message.size());
 
-    std::string decrypted = server.decrypt(encrypted);
-    DOCTEST_REQUIRE_EQ(message, decrypted);
+  std::string decrypted = server.decrypt(encrypted);
+  DOCTEST_REQUIRE_EQ(message, decrypted);
 }
 #endif

--- a/core/tests/test_injection.cpp
+++ b/core/tests/test_injection.cpp
@@ -14,11 +14,12 @@ DOCTEST_TEST_CASE("Injection methods work") {
     CoreRequest req;
     req.id = "1";
     req.method = "window.postMessage";
-    
-    // We can't really verify postMessage side effects on FakeBackend easily without
-    // extending FakeBackend to record them, but we can verify the call succeeds.
-    // Let's modify FakeBackend to be observable or just check success response.
-    
+
+    // We can't really verify postMessage side effects on FakeBackend easily
+    // without extending FakeBackend to record them, but we can verify the call
+    // succeeds. Let's modify FakeBackend to be observable or just check success
+    // response.
+
     json::Object params;
     params["hwnd"] = "0x1234";
     params["msg"] = 100.0; // WM_...
@@ -26,7 +27,7 @@ DOCTEST_TEST_CASE("Injection methods work") {
 
     CoreResponse resp = core.handle(req, {});
     DOCTEST_REQUIRE(resp.ok);
-    
+
     // Check missing params
     req.params.clear();
     resp = core.handle(req, {});

--- a/core/tests/test_trace_replay.cpp
+++ b/core/tests/test_trace_replay.cpp
@@ -6,7 +6,7 @@
 
 using namespace wininspect;
 
-static std::string read_file(const char* path) {
+static std::string read_file(const char *path) {
   std::ifstream f(path, std::ios::binary);
   std::ostringstream ss;
   ss << f.rdbuf();
@@ -15,16 +15,19 @@ static std::string read_file(const char* path) {
 
 DOCTEST_TEST_CASE("trace replay: two_clients_non_interference") {
   // Minimal replay: validate key expectations using fake backend
-  auto trace = wininspect::json::parse(read_file("formal/traces/two_clients_non_interference.json")).as_obj();
+  auto trace = wininspect::json::parse(
+                   read_file("formal/traces/two_clients_non_interference.json"))
+                   .as_obj();
   auto windows = trace.at("initial_world").as_obj().at("windows").as_arr();
 
   std::vector<FakeWindow> fw;
-  for (const auto& w : windows) {
-    auto& o = w.as_obj();
+  for (const auto &w : windows) {
+    auto &o = w.as_obj();
     auto hwnd_s = o.at("hwnd").as_str();
     // parse as hex without 0x for simplicity
     std::uint64_t hwnd = std::stoull(hwnd_s.substr(2), nullptr, 16);
-    fw.push_back({(hwnd_u64)hwnd,0,0,o.at("title").as_str(),o.at("class").as_str(), o.at("visible").as_bool()});
+    fw.push_back({(hwnd_u64)hwnd, 0, 0, o.at("title").as_str(),
+                  o.at("class").as_str(), o.at("visible").as_bool()});
   }
   FakeBackend fb(std::move(fw));
   Snapshot s = fb.capture_snapshot();
@@ -32,15 +35,15 @@ DOCTEST_TEST_CASE("trace replay: two_clients_non_interference") {
 
   // c2 ensureVisible twice -> second changed=false
   CoreRequest req;
-  req.id="c2-1";
-  req.method="window.ensureVisible";
-  req.params["hwnd"]=std::string("0x2");
-  req.params["visible"]=true;
+  req.id = "c2-1";
+  req.method = "window.ensureVisible";
+  req.params["hwnd"] = std::string("0x2");
+  req.params["visible"] = true;
 
   auto r1 = core.handle(req, s);
   DOCTEST_REQUIRE(r1.ok);
 
-  req.id="c2-2";
+  req.id = "c2-2";
   auto r2 = core.handle(req, s);
   DOCTEST_REQUIRE(r2.ok);
   DOCTEST_REQUIRE_EQ(r2.result.as_obj().at("changed").as_bool(), false);

--- a/daemon/src/main.cpp
+++ b/daemon/src/main.cpp
@@ -1,6 +1,6 @@
 #ifdef _WIN32
-int wmain(int argc, wchar_t** argv);
-int wmain(int argc, wchar_t** argv);
+int wmain(int argc, wchar_t **argv);
+int wmain(int argc, wchar_t **argv);
 int main() { return 0; } // unused for windows build
 #else
 int main() { return 0; }

--- a/daemon/src/pipe.hpp
+++ b/daemon/src/pipe.hpp
@@ -9,7 +9,7 @@ struct PipeMessage {
   std::string json;
 };
 
-bool pipe_read_message(void* hPipe, PipeMessage& out);
-bool pipe_write_message(void* hPipe, const std::string& json);
+bool pipe_read_message(void *hPipe, PipeMessage &out);
+bool pipe_write_message(void *hPipe, const std::string &json);
 
 } // namespace wininspectd

--- a/daemon/src/pipe_win32.cpp
+++ b/daemon/src/pipe_win32.cpp
@@ -1,49 +1,56 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
 #include "pipe.hpp"
+#include <windows.h>
 
 namespace wininspectd {
 
-static bool read_all(HANDLE h, void* buf, DWORD n) {
-  BYTE* p = (BYTE*)buf;
+static bool read_all(HANDLE h, void *buf, DWORD n) {
+  BYTE *p = (BYTE *)buf;
   DWORD got = 0;
   while (got < n) {
     DWORD r = 0;
-    if (!ReadFile(h, p + got, n - got, &r, nullptr)) return false;
-    if (r == 0) return false;
+    if (!ReadFile(h, p + got, n - got, &r, nullptr))
+      return false;
+    if (r == 0)
+      return false;
     got += r;
   }
   return true;
 }
 
-static bool write_all(HANDLE h, const void* buf, DWORD n) {
-  const BYTE* p = (const BYTE*)buf;
+static bool write_all(HANDLE h, const void *buf, DWORD n) {
+  const BYTE *p = (const BYTE *)buf;
   DWORD sent = 0;
   while (sent < n) {
     DWORD w = 0;
-    if (!WriteFile(h, p + sent, n - sent, &w, nullptr)) return false;
-    if (w == 0) return false;
+    if (!WriteFile(h, p + sent, n - sent, &w, nullptr))
+      return false;
+    if (w == 0)
+      return false;
     sent += w;
   }
   return true;
 }
 
-bool pipe_read_message(void* hPipeV, PipeMessage& out) {
+bool pipe_read_message(void *hPipeV, PipeMessage &out) {
   HANDLE h = (HANDLE)hPipeV;
   std::uint32_t len = 0;
-  if (!read_all(h, &len, sizeof(len))) return false;
+  if (!read_all(h, &len, sizeof(len)))
+    return false;
   std::string s;
   s.resize(len);
-  if (!read_all(h, s.data(), len)) return false;
+  if (!read_all(h, s.data(), len))
+    return false;
   out.json = std::move(s);
   return true;
 }
 
-bool pipe_write_message(void* hPipeV, const std::string& json) {
+bool pipe_write_message(void *hPipeV, const std::string &json) {
   HANDLE h = (HANDLE)hPipeV;
   std::uint32_t len = (std::uint32_t)json.size();
-  if (!write_all(h, &len, sizeof(len))) return false;
+  if (!write_all(h, &len, sizeof(len)))
+    return false;
   return write_all(h, json.data(), len);
 }
 

--- a/daemon/src/server.cpp
+++ b/daemon/src/server.cpp
@@ -1,19 +1,19 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <thread>
 #include <atomic>
 #include <map>
 #include <mutex>
+#include <thread>
+#include <windows.h>
 
 #include "pipe.hpp"
 
 #include "wininspect/core.hpp"
-#include "wininspect/win32_backend.hpp"
 #include "wininspect/fake_backend.hpp"
+#include "wininspect/win32_backend.hpp"
 
-#include "tray.hpp"
 #include "tcp_server.hpp"
+#include "tray.hpp"
 
 #include <list>
 
@@ -30,29 +30,30 @@ struct ServerState {
 };
 
 struct ClientSession {
-    std::string last_snap_id;
-    bool subscribed = false;
-    std::vector<Event> pending_events;
+  std::string last_snap_id;
+  bool subscribed = false;
+  std::vector<Event> pending_events;
 };
 
-}
+} // namespace wininspect
 
 namespace {
 
-const wchar_t* PIPE_NAME = L"\\\\.\\pipe\\wininspectd";
+const wchar_t *PIPE_NAME = L"\\\\.\\pipe\\wininspectd";
 
-std::string make_snap_id(std::uint64_t n) {
-  return "s-" + std::to_string(n);
-}
+std::string make_snap_id(std::uint64_t n) { return "s-" + std::to_string(n); }
 
-void handle_client(HANDLE hPipe, ServerState* st, IBackend* backend, bool read_only) {
+void handle_client(HANDLE hPipe, ServerState *st, IBackend *backend,
+                   bool read_only) {
   CoreEngine core(backend);
   ClientSession session;
 
-  // Each request uses snapshot_id if provided; otherwise uses a new snapshot for pure calls.
+  // Each request uses snapshot_id if provided; otherwise uses a new snapshot
+  // for pure calls.
   while (true) {
     wininspectd::PipeMessage m;
-    if (!wininspectd::pipe_read_message(hPipe, m)) break;
+    if (!wininspectd::pipe_read_message(hPipe, m))
+      break;
 
     CoreResponse resp;
     bool canonical = false;
@@ -62,16 +63,18 @@ void handle_client(HANDLE hPipe, ServerState* st, IBackend* backend, bool read_o
       resp.id = req.id;
 
       // Security: Check Read-Only mode
-      if (read_only && (req.method == "window.postMessage" || req.method == "input.send")) {
-          resp.ok = false;
-          resp.error_code = "E_ACCESS_DENIED";
-          resp.error_message = "daemon is running in read-only mode";
-          goto send;
+      if (read_only &&
+          (req.method == "window.postMessage" || req.method == "input.send")) {
+        resp.ok = false;
+        resp.error_code = "E_ACCESS_DENIED";
+        resp.error_message = "daemon is running in read-only mode";
+        goto send;
       }
 
       // canonical flag in params
       auto itc = req.params.find("canonical");
-      if (itc != req.params.end() && itc->second.is_bool()) canonical = itc->second.as_bool();
+      if (itc != req.params.end() && itc->second.is_bool())
+        canonical = itc->second.as_bool();
 
       if (req.method == "snapshot.capture") {
         Snapshot s = backend->capture_snapshot();
@@ -81,7 +84,7 @@ void handle_client(HANDLE hPipe, ServerState* st, IBackend* backend, bool read_o
           sid = make_snap_id(st->snap_counter++);
           st->snaps.emplace(sid, std::move(s));
           st->lru_order.push_back(sid);
-          
+
           if (st->lru_order.size() > ServerState::MAX_SNAPSHOTS) {
             std::string oldest = st->lru_order.front();
             st->lru_order.pop_front();
@@ -93,13 +96,13 @@ void handle_client(HANDLE hPipe, ServerState* st, IBackend* backend, bool read_o
         resp.ok = true;
         resp.result = o;
       } else if (req.method == "events.subscribe") {
-          session.subscribed = true;
-          resp.ok = true;
-          resp.result = json::Object{};
+        session.subscribed = true;
+        resp.ok = true;
+        resp.result = json::Object{};
       } else if (req.method == "events.unsubscribe") {
-          session.subscribed = false;
-          resp.ok = true;
-          resp.result = json::Object{};
+        session.subscribed = false;
+        resp.ok = true;
+        resp.result = json::Object{};
       } else if (req.method == "daemon.status") {
         json::Object o;
         {
@@ -114,7 +117,7 @@ void handle_client(HANDLE hPipe, ServerState* st, IBackend* backend, bool read_o
       } else {
         // Find snapshot
         Snapshot snap;
-        const Snapshot* old_snap_ptr = nullptr;
+        const Snapshot *old_snap_ptr = nullptr;
         Snapshot old_snap_storage;
 
         auto its = req.params.find("snapshot_id");
@@ -148,34 +151,36 @@ void handle_client(HANDLE hPipe, ServerState* st, IBackend* backend, bool read_o
             st->lru_order.remove(osid);
             st->lru_order.push_back(osid);
           }
-        } else if (req.method == "events.poll" && !session.last_snap_id.empty()) {
-            // Auto-diff against session last state
-            std::lock_guard<std::mutex> lk(st->mu);
-            auto it = st->snaps.find(session.last_snap_id);
-            if (it != st->snaps.end()) {
-                old_snap_storage = it->second;
-                old_snap_ptr = &old_snap_storage;
-            }
+        } else if (req.method == "events.poll" &&
+                   !session.last_snap_id.empty()) {
+          // Auto-diff against session last state
+          std::lock_guard<std::mutex> lk(st->mu);
+          auto it = st->snaps.find(session.last_snap_id);
+          if (it != st->snaps.end()) {
+            old_snap_storage = it->second;
+            old_snap_ptr = &old_snap_storage;
+          }
         }
 
         resp = core.handle(req, snap, old_snap_ptr);
 
         if (req.method == "events.poll" && resp.ok) {
-            // In a real system, we'd generate a temporary ID or similar.
-            // For now, we capture current state as the 'last known' for next poll.
-            Snapshot fresh = backend->capture_snapshot();
-            std::string sid;
-            {
-                std::lock_guard<std::mutex> lk(st->mu);
-                sid = make_snap_id(st->snap_counter++);
-                st->snaps.emplace(sid, fresh);
-                st->lru_order.push_back(sid);
-            }
-            session.last_snap_id = sid;
+          // In a real system, we'd generate a temporary ID or similar.
+          // For now, we capture current state as the 'last known' for next
+          // poll.
+          Snapshot fresh = backend->capture_snapshot();
+          std::string sid;
+          {
+            std::lock_guard<std::mutex> lk(st->mu);
+            sid = make_snap_id(st->snap_counter++);
+            st->snaps.emplace(sid, fresh);
+            st->lru_order.push_back(sid);
+          }
+          session.last_snap_id = sid;
         }
       }
 
-    } catch (const std::exception& e) {
+    } catch (const std::exception &e) {
       resp.ok = false;
       resp.error_code = "E_BAD_REQUEST";
       resp.error_message = e.what();
@@ -184,7 +189,8 @@ void handle_client(HANDLE hPipe, ServerState* st, IBackend* backend, bool read_o
 
   send:
     auto out = serialize_response_json(resp, canonical);
-    if (!wininspectd::pipe_write_message(hPipe, out)) break;
+    if (!wininspectd::pipe_write_message(hPipe, out))
+      break;
   }
 
   FlushFileBuffers(hPipe);
@@ -192,23 +198,24 @@ void handle_client(HANDLE hPipe, ServerState* st, IBackend* backend, bool read_o
   CloseHandle(hPipe);
 }
 
-void run_server(std::atomic<bool>* running, ServerState* st, IBackend* backend) {
+void run_server(std::atomic<bool> *running, ServerState *st,
+                IBackend *backend) {
   while (running->load()) {
     HANDLE hPipe = CreateNamedPipeW(
-      PIPE_NAME,
-      PIPE_ACCESS_DUPLEX,
-      PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
-      PIPE_UNLIMITED_INSTANCES,
-      64 * 1024,
-      64 * 1024,
-      0,
-      nullptr
-    );
+        PIPE_NAME, PIPE_ACCESS_DUPLEX,
+        PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+        PIPE_UNLIMITED_INSTANCES, 64 * 1024, 64 * 1024, 0, nullptr);
 
-    if (hPipe == INVALID_HANDLE_VALUE) break;
+    if (hPipe == INVALID_HANDLE_VALUE)
+      break;
 
-    BOOL ok = ConnectNamedPipe(hPipe, nullptr) ? TRUE : (GetLastError() == ERROR_PIPE_CONNECTED);
-    if (!ok) { CloseHandle(hPipe); continue; }
+    BOOL ok = ConnectNamedPipe(hPipe, nullptr)
+                  ? TRUE
+                  : (GetLastError() == ERROR_PIPE_CONNECTED);
+    if (!ok) {
+      CloseHandle(hPipe);
+      continue;
+    }
 
     std::thread(handle_client, hPipe, st, backend, read_only).detach();
   }
@@ -216,16 +223,19 @@ void run_server(std::atomic<bool>* running, ServerState* st, IBackend* backend) 
 
 } // namespace
 
-int wmain(int argc, wchar_t** argv) {
+int wmain(int argc, wchar_t **argv) {
   bool headless = false;
   bool bind_public = false;
   bool read_only = false;
   std::wstring auth_keys;
   int tcp_port = 1985;
   for (int i = 1; i < argc; ++i) {
-    if (std::wstring(argv[i]) == L"--headless") headless = true;
-    if (std::wstring(argv[i]) == L"--public") bind_public = true;
-    if (std::wstring(argv[i]) == L"--read-only") read_only = true;
+    if (std::wstring(argv[i]) == L"--headless")
+      headless = true;
+    if (std::wstring(argv[i]) == L"--public")
+      bind_public = true;
+    if (std::wstring(argv[i]) == L"--read-only")
+      read_only = true;
     if (std::wstring(argv[i]) == L"--auth-keys" && i + 1 < argc) {
       auth_keys = argv[++i];
     }
@@ -240,12 +250,16 @@ int wmain(int argc, wchar_t** argv) {
 
   std::thread server_thread(run_server, &running, &st, &backend, read_only);
 
-  // Start TCP server for cross-environment access (Host <-> Guest, Host <-> Wine)
+  // Start TCP server for cross-environment access (Host <-> Guest, Host <->
+  // Wine)
   std::string auth_keys_u8;
   if (!auth_keys.empty()) {
-      int len = WideCharToMultiByte(CP_UTF8, 0, auth_keys.c_str(), (int)auth_keys.size(), nullptr, 0, nullptr, nullptr);
-      auth_keys_u8.resize(len);
-      WideCharToMultiByte(CP_UTF8, 0, auth_keys.c_str(), (int)auth_keys.size(), auth_keys_u8.data(), len, nullptr, nullptr);
+    int len = WideCharToMultiByte(CP_UTF8, 0, auth_keys.c_str(),
+                                  (int)auth_keys.size(), nullptr, 0, nullptr,
+                                  nullptr);
+    auth_keys_u8.resize(len);
+    WideCharToMultiByte(CP_UTF8, 0, auth_keys.c_str(), (int)auth_keys.size(),
+                        auth_keys_u8.data(), len, nullptr, nullptr);
   }
 
   std::thread([&, tcp_port, bind_public, auth_keys_u8, read_only]() {
@@ -256,7 +270,8 @@ int wmain(int argc, wchar_t** argv) {
   if (!headless) {
     wininspectd::TrayManager tray([&]() {
       running = false;
-      // We use exit(0) to ensure the process terminates even if server_thread is blocked on ConnectNamedPipe
+      // We use exit(0) to ensure the process terminates even if server_thread
+      // is blocked on ConnectNamedPipe
       exit(0);
     });
 

--- a/daemon/src/tcp_server.cpp
+++ b/daemon/src/tcp_server.cpp
@@ -1,11 +1,11 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
+#include <iostream>
+#include <thread>
+#include <vector>
 #include <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
-#include <thread>
-#include <vector>
-#include <iostream>
 
 #include "tcp_server.hpp"
 #include "wininspect/core.hpp"
@@ -14,198 +14,245 @@
 
 namespace wininspectd {
 
-static std::string base64_encode(const std::vector<uint8_t>& in) {
-    static const char* b64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    std::string out;
-    int val = 0, valb = -6;
-    for (uint8_t c : in) {
-        val = (val << 8) + c;
-        valb += 8;
-        while (valb >= 0) {
-            out.push_back(b64[(val >> valb) & 0x3F]);
-            valb -= 6;
-        }
+static std::string base64_encode(const std::vector<uint8_t> &in) {
+  static const char *b64 =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  std::string out;
+  int val = 0, valb = -6;
+  for (uint8_t c : in) {
+    val = (val << 8) + c;
+    valb += 8;
+    while (valb >= 0) {
+      out.push_back(b64[(val >> valb) & 0x3F]);
+      valb -= 6;
     }
-    if (valb > -6) out.push_back(b64[((val << 8) >> (valb + 8)) & 0x3F]);
-    while (out.size() % 4) out.push_back('=');
-    return out;
+  }
+  if (valb > -6)
+    out.push_back(b64[((val << 8) >> (valb + 8)) & 0x3F]);
+  while (out.size() % 4)
+    out.push_back('=');
+  return out;
 }
 
-static bool verify_identity(const std::string& auth_keys_path, const std::string& identity, const std::string& sig_b64, const std::vector<uint8_t>& nonce) {
-    std::ifstream f(auth_keys_path);
-    std::string line;
-    while (std::getline(f, line)) {
-        if (line.empty() || line[0] == '#') continue;
-        if (line.find(identity) != std::string::npos) {
-            // In a production system, we'd extract the key from this line
-            return wininspect::crypto::verify_ssh_sig(nonce, sig_b64, line);
-        }
+static bool verify_identity(const std::string &auth_keys_path,
+                            const std::string &identity,
+                            const std::string &sig_b64,
+                            const std::vector<uint8_t> &nonce) {
+  std::ifstream f(auth_keys_path);
+  std::string line;
+  while (std::getline(f, line)) {
+    if (line.empty() || line[0] == '#')
+      continue;
+    if (line.find(identity) != std::string::npos) {
+      // In a production system, we'd extract the key from this line
+      return wininspect::crypto::verify_ssh_sig(nonce, sig_b64, line);
     }
-    return false;
+  }
+  return false;
 }
 
-static void handle_socket_client(SOCKET s, wininspect::ServerState* st, wininspect::IBackend* backend, std::string auth_keys, bool read_only) {
-    wininspect::CoreEngine core(backend);
-    
-    // Set 5 second timeout for handshake
-    DWORD timeout = 5000;
-    setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout, sizeof(timeout));
+static void handle_socket_client(SOCKET s, wininspect::ServerState *st,
+                                 wininspect::IBackend *backend,
+                                 std::string auth_keys, bool read_only) {
+  wininspect::CoreEngine core(backend);
 
-    if (!auth_keys.empty()) {
-        std::vector<uint8_t> nonce(32);
-        HCRYPTPROV hProv;
-        if (CryptAcquireContext(&hProv, nullptr, nullptr, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT)) {
-            CryptGenRandom(hProv, (DWORD)nonce.size(), nonce.data());
-            CryptReleaseContext(hProv, 0);
-        }
+  // Set 5 second timeout for handshake
+  DWORD timeout = 5000;
+  setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (const char *)&timeout,
+             sizeof(timeout));
 
-        wininspect::json::Object challenge;
-        challenge["type"] = "hello";
-        challenge["version"] = std::string(wininspect::PROTOCOL_VERSION);
-        challenge["nonce"] = base64_encode(nonce);
-        std::string cj = wininspect::json::dumps(challenge);
-        uint32_t clen = (uint32_t)cj.size();
-        if (!socket_write_all(s, &clen, 4) || !socket_write_all(s, cj.data(), clen)) { closesocket(s); return; }
-
-        uint32_t rlen = 0;
-        if (!socket_read_all(s, &rlen, 4)) { closesocket(s); return; }
-        std::string resp_json; resp_json.resize(rlen);
-        if (!socket_read_all(s, resp_json.data(), rlen)) { closesocket(s); return; }
-
-        try {
-            auto v = wininspect::json::parse(resp_json).as_obj();
-            if (v.at("version").as_str() != wininspect::PROTOCOL_VERSION) {
-                closesocket(s); return;
-            }
-            if (!verify_identity(auth_keys, v.at("identity").as_str(), v.at("signature").as_str(), nonce)) {
-                closesocket(s); return;
-            }
-        } catch (...) { closesocket(s); return; }
-
-        wininspect::json::Object status;
-        status["type"] = "auth_status";
-        status["ok"] = true;
-        std::string sj = wininspect::json::dumps(status);
-        uint32_t slen = (uint32_t)sj.size();
-        if (!socket_write_all(s, &slen, 4) || !socket_write_all(s, sj.data(), slen)) { closesocket(s); return; }
+  if (!auth_keys.empty()) {
+    std::vector<uint8_t> nonce(32);
+    HCRYPTPROV hProv;
+    if (CryptAcquireContext(&hProv, nullptr, nullptr, PROV_RSA_FULL,
+                            CRYPT_VERIFYCONTEXT)) {
+      CryptGenRandom(hProv, (DWORD)nonce.size(), nonce.data());
+      CryptReleaseContext(hProv, 0);
     }
 
-    // Handshake successful, set a longer idle timeout (30 mins)
-    DWORD idle_timeout = 30 * 60 * 1000;
-    setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (const char*)&idle_timeout, sizeof(idle_timeout));
+    wininspect::json::Object challenge;
+    challenge["type"] = "hello";
+    challenge["version"] = std::string(wininspect::PROTOCOL_VERSION);
+    challenge["nonce"] = base64_encode(nonce);
+    std::string cj = wininspect::json::dumps(challenge);
+    uint32_t clen = (uint32_t)cj.size();
+    if (!socket_write_all(s, &clen, 4) ||
+        !socket_write_all(s, cj.data(), clen)) {
+      closesocket(s);
+      return;
+    }
 
-    while (true) {
-        uint32_t len = 0;
-        if (!socket_read_all(s, &len, 4)) break;
-        
-        // Security: Prevent OOM/DoS by enforcing a reasonable maximum message size (10MB)
-        if (len == 0 || len > 10 * 1024 * 1024) break; 
+    uint32_t rlen = 0;
+    if (!socket_read_all(s, &rlen, 4)) {
+      closesocket(s);
+      return;
+    }
+    std::string resp_json;
+    resp_json.resize(rlen);
+    if (!socket_read_all(s, resp_json.data(), rlen)) {
+      closesocket(s);
+      return;
+    }
 
-        std::string json_req;
-        json_req.resize(len);
-        if (!socket_read_all(s, json_req.data(), len)) break;
+    try {
+      auto v = wininspect::json::parse(resp_json).as_obj();
+      if (v.at("version").as_str() != wininspect::PROTOCOL_VERSION) {
+        closesocket(s);
+        return;
+      }
+      if (!verify_identity(auth_keys, v.at("identity").as_str(),
+                           v.at("signature").as_str(), nonce)) {
+        closesocket(s);
+        return;
+      }
+    } catch (...) {
+      closesocket(s);
+      return;
+    }
 
-        wininspect::CoreResponse resp;
-        bool canonical = false;
+    wininspect::json::Object status;
+    status["type"] = "auth_status";
+    status["ok"] = true;
+    std::string sj = wininspect::json::dumps(status);
+    uint32_t slen = (uint32_t)sj.size();
+    if (!socket_write_all(s, &slen, 4) ||
+        !socket_write_all(s, sj.data(), slen)) {
+      closesocket(s);
+      return;
+    }
+  }
 
-        try {
-            auto req = wininspect::parse_request_json(json_req);
-            resp.id = req.id;
+  // Handshake successful, set a longer idle timeout (30 mins)
+  DWORD idle_timeout = 30 * 60 * 1000;
+  setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (const char *)&idle_timeout,
+             sizeof(idle_timeout));
 
-            // Security: Check Read-Only mode
-            if (read_only && (req.method == "window.postMessage" || req.method == "input.send")) {
-                resp.ok = false;
-                resp.error_code = "E_ACCESS_DENIED";
-                resp.error_message = "daemon is running in read-only mode";
-                goto send_resp;
-            }
+  while (true) {
+    uint32_t len = 0;
+    if (!socket_read_all(s, &len, 4))
+      break;
 
-            auto itc = req.params.find("canonical");
-            if (itc != req.params.end() && itc->second.is_bool()) canonical = itc->second.as_bool();
+    // Security: Prevent OOM/DoS by enforcing a reasonable maximum message size
+    // (10MB)
+    if (len == 0 || len > 10 * 1024 * 1024)
+      break;
 
-            if (req.method == "snapshot.capture") {
-                wininspect::Snapshot snap = backend->capture_snapshot();
-                resp = core.handle(req, snap);
-            } else {
-                wininspect::Snapshot snap = backend->capture_snapshot();
-                const wininspect::Snapshot* old_ptr = nullptr;
-                wininspect::Snapshot old_storage;
+    std::string json_req;
+    json_req.resize(len);
+    if (!socket_read_all(s, json_req.data(), len))
+      break;
 
-                auto itos = req.params.find("old_snapshot_id");
-                if (itos != req.params.end() && itos->second.is_str()) {
-                    // TCP server currently captures fresh for main, 
-                    // but we need to support old_snapshot if we want polling to work over TCP.
-                    // For now, we'll just handle the handle call signature.
-                }
+    wininspect::CoreResponse resp;
+    bool canonical = false;
 
-                resp = core.handle(req, snap, old_ptr);
-            }
-        } catch (...) {
-            resp.ok = false;
-            resp.error_code = "E_BAD_REQUEST";
+    try {
+      auto req = wininspect::parse_request_json(json_req);
+      resp.id = req.id;
+
+      // Security: Check Read-Only mode
+      if (read_only &&
+          (req.method == "window.postMessage" || req.method == "input.send")) {
+        resp.ok = false;
+        resp.error_code = "E_ACCESS_DENIED";
+        resp.error_message = "daemon is running in read-only mode";
+        goto send_resp;
+      }
+
+      auto itc = req.params.find("canonical");
+      if (itc != req.params.end() && itc->second.is_bool())
+        canonical = itc->second.as_bool();
+
+      if (req.method == "snapshot.capture") {
+        wininspect::Snapshot snap = backend->capture_snapshot();
+        resp = core.handle(req, snap);
+      } else {
+        wininspect::Snapshot snap = backend->capture_snapshot();
+        const wininspect::Snapshot *old_ptr = nullptr;
+        wininspect::Snapshot old_storage;
+
+        auto itos = req.params.find("old_snapshot_id");
+        if (itos != req.params.end() && itos->second.is_str()) {
+          // TCP server currently captures fresh for main,
+          // but we need to support old_snapshot if we want polling to work over
+          // TCP. For now, we'll just handle the handle call signature.
         }
 
-    send_resp:
-        std::string out = wininspect::serialize_response_json(resp, canonical);
-        uint32_t out_len = (uint32_t)out.size();
-        if (!socket_write_all(s, &out_len, 4)) break;
-        if (!socket_write_all(s, out.data(), out_len)) break;
+        resp = core.handle(req, snap, old_ptr);
+      }
+    } catch (...) {
+      resp.ok = false;
+      resp.error_code = "E_BAD_REQUEST";
     }
-    closesocket(s);
+
+  send_resp:
+    std::string out = wininspect::serialize_response_json(resp, canonical);
+    uint32_t out_len = (uint32_t)out.size();
+    if (!socket_write_all(s, &out_len, 4))
+      break;
+    if (!socket_write_all(s, out.data(), out_len))
+      break;
+  }
+  closesocket(s);
 }
 
-TcpServer::TcpServer(int port, wininspect::ServerState* state, wininspect::IBackend* backend)
+TcpServer::TcpServer(int port, wininspect::ServerState *state,
+                     wininspect::IBackend *backend)
     : port_(port), state_(state), backend_(backend) {}
 
 TcpServer::~TcpServer() {}
 
-void TcpServer::start(std::atomic<bool>* running, bool bind_public, const std::string& auth_keys, bool read_only) {
-    WSADATA wsaData;
-    if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) return;
+void TcpServer::start(std::atomic<bool> *running, bool bind_public,
+                      const std::string &auth_keys, bool read_only) {
+  WSADATA wsaData;
+  if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0)
+    return;
 
-    SOCKET listen_sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-    if (listen_sock == INVALID_SOCKET) return;
+  SOCKET listen_sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  if (listen_sock == INVALID_SOCKET)
+    return;
 
-    sockaddr_in addr{};
-    addr.sin_family = AF_INET;
-    // Security: Bind to localhost (127.0.0.1) by default. 
-    // Only bind to all interfaces (0.0.0.0) if explicitly requested by --public.
-    addr.sin_addr.s_addr = htonl(bind_public ? INADDR_ANY : INADDR_LOOPBACK);
-    addr.sin_port = htons((u_short)port_);
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  // Security: Bind to localhost (127.0.0.1) by default.
+  // Only bind to all interfaces (0.0.0.0) if explicitly requested by --public.
+  addr.sin_addr.s_addr = htonl(bind_public ? INADDR_ANY : INADDR_LOOPBACK);
+  addr.sin_port = htons((u_short)port_);
 
-    if (bind(listen_sock, (sockaddr*)&addr, sizeof(addr)) == SOCKET_ERROR) {
-        closesocket(listen_sock);
-        return;
-    }
-
-    if (listen(listen_sock, SOMAXCONN) == SOCKET_ERROR) {
-        closesocket(listen_sock);
-        return;
-    }
-
-    // Set non-blocking to check 'running' flag
-    u_long mode = 1;
-    ioctlsocket(listen_sock, FIONBIO, &mode);
-
-    while (running->load()) {
-        SOCKET client = accept(listen_sock, nullptr, nullptr);
-        if (client == INVALID_SOCKET) {
-            if (WSAGetLastError() == WSAEWOULDBLOCK) {
-                Sleep(100);
-                continue;
-            }
-            break;
-        }
-
-        // Set back to blocking for the handler thread
-        u_long m2 = 0;
-        ioctlsocket(client, FIONBIO, &m2);
-
-        std::thread(handle_socket_client, client, state_, backend_, auth_keys, read_only).detach();
-    }
-
+  if (bind(listen_sock, (sockaddr *)&addr, sizeof(addr)) == SOCKET_ERROR) {
     closesocket(listen_sock);
-    WSACleanup();
+    return;
+  }
+
+  if (listen(listen_sock, SOMAXCONN) == SOCKET_ERROR) {
+    closesocket(listen_sock);
+    return;
+  }
+
+  // Set non-blocking to check 'running' flag
+  u_long mode = 1;
+  ioctlsocket(listen_sock, FIONBIO, &mode);
+
+  while (running->load()) {
+    SOCKET client = accept(listen_sock, nullptr, nullptr);
+    if (client == INVALID_SOCKET) {
+      if (WSAGetLastError() == WSAEWOULDBLOCK) {
+        Sleep(100);
+        continue;
+      }
+      break;
+    }
+
+    // Set back to blocking for the handler thread
+    u_long m2 = 0;
+    ioctlsocket(client, FIONBIO, &m2);
+
+    std::thread(handle_socket_client, client, state_, backend_, auth_keys,
+                read_only)
+        .detach();
+  }
+
+  closesocket(listen_sock);
+  WSACleanup();
 }
 
 } // namespace wininspectd

--- a/daemon/src/tcp_server.hpp
+++ b/daemon/src/tcp_server.hpp
@@ -1,26 +1,28 @@
 #pragma once
 #include <atomic>
-#include <string>
 #include <functional>
+#include <string>
 
 namespace wininspect {
-    struct ServerState;
-    class IBackend;
-}
+struct ServerState;
+class IBackend;
+} // namespace wininspect
 
 namespace wininspectd {
 
 class TcpServer {
 public:
-    TcpServer(int port, wininspect::ServerState* state, wininspect::IBackend* backend);
-    ~TcpServer();
+  TcpServer(int port, wininspect::ServerState *state,
+            wininspect::IBackend *backend);
+  ~TcpServer();
 
-    void start(std::atomic<bool>* running, bool bind_public = false, const std::string& auth_keys = "", bool read_only = false);
+  void start(std::atomic<bool> *running, bool bind_public = false,
+             const std::string &auth_keys = "", bool read_only = false);
 
 private:
-    int port_;
-    wininspect::ServerState* state_;
-    wininspect::IBackend* backend_;
+  int port_;
+  wininspect::ServerState *state_;
+  wininspect::IBackend *backend_;
 };
 
 } // namespace wininspectd

--- a/daemon/src/tray.cpp
+++ b/daemon/src/tray.cpp
@@ -5,105 +5,111 @@ namespace wininspectd {
 
 TrayManager::TrayManager(OnExitCallback onExit) : onExit_(onExit) {}
 
-TrayManager::~TrayManager() {
-    stop();
-}
+TrayManager::~TrayManager() { stop(); }
 
 bool TrayManager::init(HINSTANCE hInstance) {
-    hInst_ = hInstance;
+  hInst_ = hInstance;
 
-    WNDCLASSEXW wc = { sizeof(WNDCLASSEXW) };
-    wc.lpfnWndProc = windowProc;
-    wc.hInstance = hInst_;
-    wc.lpszClassName = L"WinInspectTrayWindow";
+  WNDCLASSEXW wc = {sizeof(WNDCLASSEXW)};
+  wc.lpfnWndProc = windowProc;
+  wc.hInstance = hInst_;
+  wc.lpszClassName = L"WinInspectTrayWindow";
 
-    if (!RegisterClassExW(&wc)) return false;
+  if (!RegisterClassExW(&wc))
+    return false;
 
-    hwnd_ = CreateWindowExW(0, wc.lpszClassName, L"WinInspect Daemon Tray", 0, 0, 0, 0, 0, HWND_MESSAGE, nullptr, hInst_, this);
-    if (!hwnd_) return false;
+  hwnd_ = CreateWindowExW(0, wc.lpszClassName, L"WinInspect Daemon Tray", 0, 0,
+                          0, 0, 0, HWND_MESSAGE, nullptr, hInst_, this);
+  if (!hwnd_)
+    return false;
 
-    NOTIFYICONDATAW nid = { sizeof(NOTIFYICONDATAW) };
-    nid.hWnd = hwnd_;
-    nid.uID = 1;
-    nid.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
-    nid.uCallbackMessage = WM_TRAYICON;
-    nid.hIcon = LoadIcon(nullptr, IDI_APPLICATION);
-    wcscpy_s(nid.szTip, L"WinInspect Daemon");
+  NOTIFYICONDATAW nid = {sizeof(NOTIFYICONDATAW)};
+  nid.hWnd = hwnd_;
+  nid.uID = 1;
+  nid.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
+  nid.uCallbackMessage = WM_TRAYICON;
+  nid.hIcon = LoadIcon(nullptr, IDI_APPLICATION);
+  wcscpy_s(nid.szTip, L"WinInspect Daemon");
 
-    if (!Shell_NotifyIconW(NIM_ADD, &nid)) return false;
+  if (!Shell_NotifyIconW(NIM_ADD, &nid))
+    return false;
 
-    return true;
+  return true;
 }
 
 void TrayManager::run() {
-    running_ = true;
-    MSG msg;
-    while (running_ && GetMessage(&msg, nullptr, 0, 0)) {
-        TranslateMessage(&msg);
-        DispatchMessage(&msg);
-    }
+  running_ = true;
+  MSG msg;
+  while (running_ && GetMessage(&msg, nullptr, 0, 0)) {
+    TranslateMessage(&msg);
+    DispatchMessage(&msg);
+  }
 }
 
 void TrayManager::stop() {
-    if (hwnd_) {
-        NOTIFYICONDATAW nid = { sizeof(NOTIFYICONDATAW) };
-        nid.hWnd = hwnd_;
-        nid.uID = 1;
-        Shell_NotifyIconW(NIM_DELETE, &nid);
-        DestroyWindow(hwnd_);
-        hwnd_ = nullptr;
-    }
-    running_ = false;
+  if (hwnd_) {
+    NOTIFYICONDATAW nid = {sizeof(NOTIFYICONDATAW)};
+    nid.hWnd = hwnd_;
+    nid.uID = 1;
+    Shell_NotifyIconW(NIM_DELETE, &nid);
+    DestroyWindow(hwnd_);
+    hwnd_ = nullptr;
+  }
+  running_ = false;
 }
 
-LRESULT CALLBACK TrayManager::windowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
-    TrayManager* self = nullptr;
-    if (uMsg == WM_NCCREATE) {
-        CREATESTRUCT* cs = reinterpret_cast<CREATESTRUCT*>(lParam);
-        self = reinterpret_cast<TrayManager*>(cs->lpCreateParams);
-        SetWindowLongPtr(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(self));
-    } else {
-        self = reinterpret_cast<TrayManager*>(GetWindowLongPtr(hwnd, GWLP_USERDATA));
-    }
+LRESULT CALLBACK TrayManager::windowProc(HWND hwnd, UINT uMsg, WPARAM wParam,
+                                         LPARAM lParam) {
+  TrayManager *self = nullptr;
+  if (uMsg == WM_NCCREATE) {
+    CREATESTRUCT *cs = reinterpret_cast<CREATESTRUCT *>(lParam);
+    self = reinterpret_cast<TrayManager *>(cs->lpCreateParams);
+    SetWindowLongPtr(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(self));
+  } else {
+    self =
+        reinterpret_cast<TrayManager *>(GetWindowLongPtr(hwnd, GWLP_USERDATA));
+  }
 
-    if (self) {
-        if (uMsg == WM_TRAYICON) {
-            self->handleTrayMessage(lParam);
-            return 0;
-        } else if (uMsg == WM_COMMAND) {
-            if (LOWORD(wParam) == ID_TRAY_EXIT) {
-                if (self->onExit_) self->onExit_();
-                self->stop();
-            } else if (LOWORD(wParam) == ID_TRAY_ABOUT) {
+  if (self) {
+    if (uMsg == WM_TRAYICON) {
+      self->handleTrayMessage(lParam);
+      return 0;
+    } else if (uMsg == WM_COMMAND) {
+      if (LOWORD(wParam) == ID_TRAY_EXIT) {
+        if (self->onExit_)
+          self->onExit_();
+        self->stop();
+      } else if (LOWORD(wParam) == ID_TRAY_ABOUT) {
                 MessageBoxW(hwnd, L"WinInspect Daemon
 Monitoring windows with style.", L"About", MB_OK | MB_ICONINFORMATION);
-            }
-            return 0;
-        }
+      }
+      return 0;
     }
+  }
 
-    return DefWindowProcW(hwnd, uMsg, wParam, lParam);
+  return DefWindowProcW(hwnd, uMsg, wParam, lParam);
 }
 
 void TrayManager::handleTrayMessage(LPARAM lParam) {
-    if (lParam == WM_RBUTTONUP || lParam == WM_LBUTTONUP) {
-        showContextMenu();
-    }
+  if (lParam == WM_RBUTTONUP || lParam == WM_LBUTTONUP) {
+    showContextMenu();
+  }
 }
 
 void TrayManager::showContextMenu() {
-    HMENU hMenu = CreatePopupMenu();
-    if (hMenu) {
-        InsertMenuW(hMenu, 0, MF_BYPOSITION | MF_STRING, ID_TRAY_ABOUT, L"About");
-        InsertMenuW(hMenu, 1, MF_BYPOSITION | MF_SEPARATOR, 0, nullptr);
-        InsertMenuW(hMenu, 2, MF_BYPOSITION | MF_STRING, ID_TRAY_EXIT, L"Exit");
+  HMENU hMenu = CreatePopupMenu();
+  if (hMenu) {
+    InsertMenuW(hMenu, 0, MF_BYPOSITION | MF_STRING, ID_TRAY_ABOUT, L"About");
+    InsertMenuW(hMenu, 1, MF_BYPOSITION | MF_SEPARATOR, 0, nullptr);
+    InsertMenuW(hMenu, 2, MF_BYPOSITION | MF_STRING, ID_TRAY_EXIT, L"Exit");
 
-        POINT pt;
-        GetCursorPos(&pt);
-        SetForegroundWindow(hwnd_);
-        TrackPopupMenu(hMenu, TPM_BOTTOMALIGN | TPM_LEFTALIGN, pt.x, pt.y, 0, hwnd_, nullptr);
-        DestroyMenu(hMenu);
-    }
+    POINT pt;
+    GetCursorPos(&pt);
+    SetForegroundWindow(hwnd_);
+    TrackPopupMenu(hMenu, TPM_BOTTOMALIGN | TPM_LEFTALIGN, pt.x, pt.y, 0, hwnd_,
+                   nullptr);
+    DestroyMenu(hMenu);
+  }
 }
 
 } // namespace wininspectd

--- a/daemon/src/tray.hpp
+++ b/daemon/src/tray.hpp
@@ -2,35 +2,36 @@
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
 #include <functional>
+#include <windows.h>
 
 namespace wininspectd {
 
 class TrayManager {
 public:
-    using OnExitCallback = std::function<void()>;
+  using OnExitCallback = std::function<void()>;
 
-    TrayManager(OnExitCallback onExit);
-    ~TrayManager();
+  TrayManager(OnExitCallback onExit);
+  ~TrayManager();
 
-    bool init(HINSTANCE hInstance);
-    void run();
-    void stop();
+  bool init(HINSTANCE hInstance);
+  void run();
+  void stop();
 
 private:
-    static LRESULT CALLBACK windowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
-    void handleTrayMessage(LPARAM lParam);
-    void showContextMenu();
+  static LRESULT CALLBACK windowProc(HWND hwnd, UINT uMsg, WPARAM wParam,
+                                     LPARAM lParam);
+  void handleTrayMessage(LPARAM lParam);
+  void showContextMenu();
 
-    HWND hwnd_ = nullptr;
-    HINSTANCE hInst_ = nullptr;
-    OnExitCallback onExit_;
-    bool running_ = false;
+  HWND hwnd_ = nullptr;
+  HINSTANCE hInst_ = nullptr;
+  OnExitCallback onExit_;
+  bool running_ = false;
 
-    static constexpr UINT WM_TRAYICON = WM_USER + 1;
-    static constexpr UINT ID_TRAY_EXIT = 1001;
-    static constexpr UINT ID_TRAY_ABOUT = 1002;
+  static constexpr UINT WM_TRAYICON = WM_USER + 1;
+  static constexpr UINT ID_TRAY_EXIT = 1001;
+  static constexpr UINT ID_TRAY_ABOUT = 1002;
 };
 
 } // namespace wininspectd

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,5 +2,68 @@
 set -euo pipefail
 
 echo "--- Linting ---"
-# Placeholder for linting logic
-echo "[lint] Mock lint pass."
+
+failed=0
+
+# C++ Linting
+if command -v clang-format &> /dev/null; then
+    echo "Running clang-format..."
+    # Find all C++ source files
+    # Exclude build directories and third_party if any
+    files=$(find core daemon clients -type f \( -name "*.cpp" -o -name "*.h" -o -name "*.hpp" \))
+
+    if [ -n "$files" ]; then
+        # Capture output to avoid noise if successful, but show if failed
+        if ! clang-format --dry-run --Werror $files; then
+            echo "ERROR: clang-format failed. Run clang-format -i on the files to fix."
+            failed=1
+        else
+            echo "clang-format passed."
+        fi
+    fi
+else
+    echo "WARNING: clang-format not found. Skipping C++ linting."
+    # In CI, we expect tools to be present.
+    if [ "${CI:-}" == "true" ]; then
+        echo "ERROR: clang-format is required in CI."
+        failed=1
+    fi
+fi
+
+# Go Linting
+if command -v go &> /dev/null; then
+    echo "Running Go checks..."
+    if [ -d "clients/portable" ]; then
+        pushd "clients/portable" > /dev/null
+
+        echo "Running go vet..."
+        if ! go vet ./...; then
+            echo "ERROR: go vet failed."
+            failed=1
+        fi
+
+        echo "Running go fmt..."
+        # go fmt returns the names of files it modified (or would modify)
+        formatted_files=$(go fmt ./...)
+        if [ -n "$formatted_files" ]; then
+            echo "ERROR: go fmt found unformatted files:"
+            echo "$formatted_files"
+            failed=1
+        fi
+
+        popd > /dev/null
+    fi
+else
+    echo "WARNING: go not found. Skipping Go linting."
+    if [ "${CI:-}" == "true" ]; then
+        echo "ERROR: go is required in CI."
+        failed=1
+    fi
+fi
+
+if [ $failed -ne 0 ]; then
+    echo "Linting failed."
+    exit 1
+fi
+
+echo "Linting passed."

--- a/scripts/wbab-test.sh
+++ b/scripts/wbab-test.sh
@@ -3,3 +3,12 @@ set -euo pipefail
 # In WBAB mode, this would run layered tests + contract + policy gates.
 echo "[wbab-test] running local ctest as placeholder."
 ctest --test-dir build -C Release --output-on-failure
+
+if command -v go &> /dev/null; then
+    if [ -d "clients/portable" ]; then
+        echo "Running Go tests..."
+        pushd "clients/portable" > /dev/null
+        go test ./...
+        popd > /dev/null
+    fi
+fi

--- a/tools/wbab
+++ b/tools/wbab
@@ -27,6 +27,15 @@ run_local_build() {
 
 run_local_test() {
   ctest --test-dir "${ROOT}/build" -C Release --output-on-failure
+
+  if command -v go &> /dev/null; then
+    if [ -d "${ROOT}/clients/portable" ]; then
+      echo "Running Go tests..."
+      pushd "${ROOT}/clients/portable" > /dev/null
+      go test ./...
+      popd > /dev/null
+    fi
+  fi
 }
 
 case "${cmd}" in


### PR DESCRIPTION
Implemented the WBAB linting and testing stages in the CI/CD pipeline for release tags.

Key changes:
1.  **Linting**: Added `clang-format` checks for C++ and `go vet`/`go fmt` for Go in `scripts/lint.sh`. Added a `.clang-format` file.
2.  **Testing**: Enhanced `tools/wbab` and `scripts/wbab-test.sh` to run Go tests alongside C++ tests (`ctest`).
3.  **CI/CD**: Updated `.github/workflows/release.yml` to execute `wbab lint` and `wbab test` steps. The `test` step runs after build and before packaging, ensuring that only validated binaries are packaged into the installer.
4.  **Codebase**: Applied `clang-format` and fixed Go syntax errors in `clients/portable/main.go` to pass the new strict linting checks.

This ensures that the same systems and approaches are used for local development and CI/CD, and that the final installer is validated before release. The repository is now ready for the v0.0.1 release tag.

---
*PR created automatically by Jules for task [13654964116635685540](https://jules.google.com/task/13654964116635685540) started by @mark-e-deyoung*