### PR TITLE
Add UI Automation support and robust input injection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,10 @@ target_include_directories(wininspect_core PRIVATE
 )
 
 if (WIN32)
+  target_link_libraries(wininspect_core PUBLIC ole32 oleaut32 uuid)
+endif()
+
+if (WIN32)
   add_executable(wininspectd
     daemon/src/server.cpp
     daemon/src/pipe_win32.cpp
@@ -50,6 +54,7 @@ if (WININSPECT_BUILD_TESTS)
     core/tests/test_trace_replay.cpp
     core/tests/test_injection.cpp
     core/tests/test_crypto.cpp
+    core/tests/test_uia.cpp
   )
   target_include_directories(test_core PRIVATE core/include third_party)
   target_link_libraries(test_core PRIVATE wininspect_core)

--- a/core/include/wininspect/backend.hpp
+++ b/core/include/wininspect/backend.hpp
@@ -32,6 +32,14 @@ public:
                             uint64_t lparam) = 0;
   virtual bool send_input(const std::vector<uint8_t> &raw_input_data) = 0;
 
+  // Higher-level injection helpers
+  virtual bool send_mouse_click(int x, int y, int button) = 0; // 0=left, 1=right, 2=middle
+  virtual bool send_key_press(int vk) = 0;
+  virtual bool send_text(const std::string &text) = 0;
+
+  // UI Automation
+  virtual std::vector<UIElementInfo> inspect_ui_elements(hwnd_u64 parent) = 0;
+
   // Event polling
   virtual std::vector<Event> poll_events(const Snapshot &old_snap,
                                          const Snapshot &new_snap) = 0;

--- a/core/include/wininspect/fake_backend.hpp
+++ b/core/include/wininspect/fake_backend.hpp
@@ -34,13 +34,27 @@ public:
                     uint64_t lparam) override;
   bool send_input(const std::vector<uint8_t> &raw_input_data) override;
 
+  bool send_mouse_click(int x, int y, int button) override;
+  bool send_key_press(int vk) override;
+  bool send_text(const std::string &text) override;
+
+  std::vector<UIElementInfo> inspect_ui_elements(hwnd_u64 parent) override;
+
+  // Test helpers
+  void add_fake_ui_element(hwnd_u64 parent, const UIElementInfo &info);
+  std::vector<std::string> get_injected_events() const;
+  void clear_injected_events();
+
   std::vector<Event> poll_events(const Snapshot &old_snap,
                                  const Snapshot &new_snap) override;
 
 private:
-  std::mutex mu_;
+  mutable std::mutex mu_;
   std::map<hwnd_u64, FakeWindow> w_;
   hwnd_u64 foreground_ = 0;
+
+  std::map<hwnd_u64, std::vector<UIElementInfo>> ui_elements_;
+  std::vector<std::string> injected_events_;
 };
 
 } // namespace wininspect

--- a/core/include/wininspect/types.hpp
+++ b/core/include/wininspect/types.hpp
@@ -48,4 +48,14 @@ struct Event {
   std::string property; // for "window.changed"
 };
 
+struct UIElementInfo {
+  std::string automation_id;
+  std::string name;
+  std::string class_name;
+  std::string control_type;
+  Rect bounding_rect{};
+  bool enabled = false;
+  bool visible = false;
+};
+
 } // namespace wininspect

--- a/core/include/wininspect/win32_backend.hpp
+++ b/core/include/wininspect/win32_backend.hpp
@@ -21,6 +21,12 @@ public:
                     uint64_t lparam) override;
   bool send_input(const std::vector<uint8_t> &raw_input_data) override;
 
+  bool send_mouse_click(int x, int y, int button) override;
+  bool send_key_press(int vk) override;
+  bool send_text(const std::string &text) override;
+
+  std::vector<UIElementInfo> inspect_ui_elements(hwnd_u64 parent) override;
+
   std::vector<Event> poll_events(const Snapshot &old_snap,
                                  const Snapshot &new_snap) override;
 };

--- a/core/src/win32_backend.cpp
+++ b/core/src/win32_backend.cpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 #include <windows.h>
+#include <UIAutomation.h>
+#include <comdef.h>
 
 namespace wininspect {
 
@@ -25,6 +27,12 @@ static std::string w2u8(const std::wstring &ws) {
   WideCharToMultiByte(CP_UTF8, 0, ws.c_str(), (int)ws.size(), out.data(), len,
                       nullptr, nullptr);
   return out;
+}
+
+static std::string bstr_to_utf8(BSTR bstr) {
+  if (!bstr) return {};
+  std::wstring ws(bstr, SysStringLen(bstr));
+  return w2u8(ws);
 }
 
 static std::wstring get_window_text_w(HWND hwnd) {
@@ -182,6 +190,167 @@ bool Win32Backend::send_input(const std::vector<uint8_t> &raw_input_data) {
   return SendInput(count, const_cast<INPUT *>(pInputs), sizeof(INPUT)) == count;
 }
 
+bool Win32Backend::send_mouse_click(int x, int y, int button) {
+    // 0=left, 1=right, 2=middle
+    // Use absolute coordinates
+    int sw = GetSystemMetrics(SM_CXSCREEN);
+    int sh = GetSystemMetrics(SM_CYSCREEN);
+    if (sw == 0) sw = 1;
+    if (sh == 0) sh = 1;
+
+    // Normalize to 0-65535
+    int nx = (x * 65535) / sw;
+    int ny = (y * 65535) / sh;
+
+    INPUT inputs[2] = {};
+    inputs[0].type = INPUT_MOUSE;
+    inputs[0].mi.dx = nx;
+    inputs[0].mi.dy = ny;
+    inputs[0].mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_MOVE;
+
+    if (button == 0) {
+        inputs[0].mi.dwFlags |= MOUSEEVENTF_LEFTDOWN;
+        inputs[1] = inputs[0];
+        inputs[1].mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_LEFTUP;
+    } else if (button == 1) {
+        inputs[0].mi.dwFlags |= MOUSEEVENTF_RIGHTDOWN;
+        inputs[1] = inputs[0];
+        inputs[1].mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_RIGHTUP;
+    } else if (button == 2) {
+        inputs[0].mi.dwFlags |= MOUSEEVENTF_MIDDLEDOWN;
+        inputs[1] = inputs[0];
+        inputs[1].mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_MIDDLEUP;
+    } else {
+        return false;
+    }
+
+    // Send click
+    return SendInput(2, inputs, sizeof(INPUT)) == 2;
+}
+
+bool Win32Backend::send_key_press(int vk) {
+    INPUT inputs[2] = {};
+    inputs[0].type = INPUT_KEYBOARD;
+    inputs[0].ki.wVk = (WORD)vk;
+
+    inputs[1] = inputs[0];
+    inputs[1].ki.dwFlags = KEYEVENTF_KEYUP;
+
+    return SendInput(2, inputs, sizeof(INPUT)) == 2;
+}
+
+bool Win32Backend::send_text(const std::string &text) {
+    std::wstring wtext;
+    int len = MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, NULL, 0);
+    if (len > 0) {
+        wtext.resize(len - 1);
+        MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, wtext.data(), len);
+    }
+
+    if (wtext.empty()) return true;
+
+    std::vector<INPUT> inputs;
+    inputs.reserve(wtext.size() * 2);
+
+    for (wchar_t c : wtext) {
+        INPUT i = {};
+        i.type = INPUT_KEYBOARD;
+        i.ki.wScan = c;
+        i.ki.dwFlags = KEYEVENTF_UNICODE;
+        inputs.push_back(i);
+
+        i.ki.dwFlags |= KEYEVENTF_KEYUP;
+        inputs.push_back(i);
+    }
+
+    return SendInput((UINT)inputs.size(), inputs.data(), sizeof(INPUT)) == inputs.size();
+}
+
+std::vector<UIElementInfo> Win32Backend::inspect_ui_elements(hwnd_u64 parent) {
+    std::vector<UIElementInfo> results;
+
+    // Attempt to initialize COM. If already initialized, it might fail but that's ok if we can create the instance.
+    HRESULT hrInit = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+    // Ignore result, just proceed to create instance.
+
+    IUIAutomation* pAutomation = NULL;
+    HRESULT hr = CoCreateInstance(CLSID_CUIAutomation, NULL, CLSCTX_INPROC_SERVER, IID_IUIAutomation, (void**)&pAutomation);
+    if (FAILED(hr)) {
+        // Log failure?
+        if (SUCCEEDED(hrInit)) CoUninitialize();
+        return results;
+    }
+
+    IUIAutomationElement* pRoot = NULL;
+    HWND hParent = from_u64(parent);
+    if (IsWindow(hParent)) {
+        hr = pAutomation->ElementFromHandle(hParent, &pRoot);
+    } else {
+        // If invalid handle, maybe use desktop? No, just return empty.
+    }
+
+    if (SUCCEEDED(hr) && pRoot) {
+        // Find children
+        IUIAutomationCondition* pTrueCondition = NULL;
+        pAutomation->CreateTrueCondition(&pTrueCondition);
+        IUIAutomationElementArray* pChildren = NULL;
+        if (pTrueCondition) {
+            pRoot->FindAll(TreeScope_Children, pTrueCondition, &pChildren);
+            pTrueCondition->Release();
+        }
+
+        if (pChildren) {
+            int length = 0;
+            pChildren->get_Length(&length);
+            for (int i = 0; i < length; i++) {
+                IUIAutomationElement* pNode = NULL;
+                if (SUCCEEDED(pChildren->GetElement(i, &pNode)) && pNode) {
+                    UIElementInfo info;
+
+                    BSTR bStr = NULL;
+                    if (SUCCEEDED(pNode->get_CurrentAutomationId(&bStr))) {
+                        info.automation_id = bstr_to_utf8(bStr);
+                        SysFreeString(bStr);
+                    }
+                    if (SUCCEEDED(pNode->get_CurrentName(&bStr))) {
+                        info.name = bstr_to_utf8(bStr);
+                        SysFreeString(bStr);
+                    }
+                    if (SUCCEEDED(pNode->get_CurrentClassName(&bStr))) {
+                        info.class_name = bstr_to_utf8(bStr);
+                        SysFreeString(bStr);
+                    }
+                    // Control type is int, convert to string?
+                    CONTROLTYPEID cType;
+                    if (SUCCEEDED(pNode->get_CurrentControlType(&cType))) {
+                         // Simple mapping or just raw ID
+                         info.control_type = std::to_string(cType);
+                    }
+
+                    RECT r = {};
+                    if (SUCCEEDED(pNode->get_CurrentBoundingRectangle(&r))) {
+                        info.bounding_rect = {r.left, r.top, r.right, r.bottom};
+                    }
+
+                    BOOL bVal = FALSE;
+                    if (SUCCEEDED(pNode->get_CurrentIsEnabled(&bVal))) info.enabled = bVal;
+                    if (SUCCEEDED(pNode->get_CurrentIsOffscreen(&bVal))) info.visible = !bVal; // IsOffscreen means NOT visible usually
+
+                    results.push_back(info);
+                    pNode->Release();
+                }
+            }
+            pChildren->Release();
+        }
+        pRoot->Release();
+    }
+
+    pAutomation->Release();
+    if (SUCCEEDED(hrInit)) CoUninitialize();
+
+    return results;
+}
+
 static std::vector<hwnd_u64> sorted(std::vector<hwnd_u64> v) {
   std::sort(v.begin(), v.end());
   return v;
@@ -231,6 +400,12 @@ bool Win32Backend::post_message(hwnd_u64, uint32_t, uint64_t, uint64_t) {
   return false;
 }
 bool Win32Backend::send_input(const std::vector<uint8_t> &) { return false; }
+
+bool Win32Backend::send_mouse_click(int, int, int) { return false; }
+bool Win32Backend::send_key_press(int) { return false; }
+bool Win32Backend::send_text(const std::string &) { return false; }
+std::vector<UIElementInfo> Win32Backend::inspect_ui_elements(hwnd_u64) { return {}; }
+
 std::vector<Event> Win32Backend::poll_events(const Snapshot &,
                                              const Snapshot &) {
   return {};

--- a/core/tests/test_injection.cpp
+++ b/core/tests/test_injection.cpp
@@ -53,4 +53,57 @@ DOCTEST_TEST_CASE("Injection methods work") {
     resp = core.handle(req, {});
     DOCTEST_REQUIRE(!resp.ok);
   }
+
+  // Test input.mouseClick
+  {
+    CoreRequest req;
+    req.id = "3";
+    req.method = "input.mouseClick";
+    json::Object params;
+    params["x"] = 100.0;
+    params["y"] = 200.0;
+    params["button"] = 0.0;
+    req.params = params;
+
+    CoreResponse resp = core.handle(req, {});
+    DOCTEST_REQUIRE(resp.ok);
+
+    auto events = backend.get_injected_events();
+    DOCTEST_REQUIRE(events.size() > 0);
+    DOCTEST_REQUIRE(events.back() == "mouse_click:100,200,0");
+  }
+
+  // Test input.keyPress
+  {
+    CoreRequest req;
+    req.id = "4";
+    req.method = "input.keyPress";
+    json::Object params;
+    params["vk"] = 65.0; // 'A'
+    req.params = params;
+
+    CoreResponse resp = core.handle(req, {});
+    DOCTEST_REQUIRE(resp.ok);
+
+    auto events = backend.get_injected_events();
+    DOCTEST_REQUIRE(events.size() > 0);
+    DOCTEST_REQUIRE(events.back() == "key_press:65");
+  }
+
+  // Test input.text
+  {
+    CoreRequest req;
+    req.id = "5";
+    req.method = "input.text";
+    json::Object params;
+    params["text"] = "hello";
+    req.params = params;
+
+    CoreResponse resp = core.handle(req, {});
+    DOCTEST_REQUIRE(resp.ok);
+
+    auto events = backend.get_injected_events();
+    DOCTEST_REQUIRE(events.size() > 0);
+    DOCTEST_REQUIRE(events.back() == "text:hello");
+  }
 }

--- a/core/tests/test_uia.cpp
+++ b/core/tests/test_uia.cpp
@@ -1,0 +1,43 @@
+#include "doctest/doctest.h"
+#include "wininspect/core.hpp"
+#include "wininspect/fake_backend.hpp"
+
+using namespace wininspect;
+
+DOCTEST_TEST_CASE("UI Inspection works") {
+  FakeBackend backend({});
+
+  // Setup fake UI elements
+  UIElementInfo u1;
+  u1.automation_id = "btn1";
+  u1.name = "Button 1";
+  u1.control_type = "50000"; // Button
+  u1.bounding_rect = {10, 10, 50, 30};
+  u1.enabled = true;
+  u1.visible = true;
+
+  backend.add_fake_ui_element(0x1234, u1);
+
+  CoreEngine core(&backend);
+  Snapshot s; // Empty snapshot fine for fake backend
+
+  CoreRequest req;
+  req.id = "1";
+  req.method = "ui.inspect";
+  json::Object params;
+  params["hwnd"] = "0x1234";
+  req.params = params;
+
+  CoreResponse resp = core.handle(req, s);
+  DOCTEST_REQUIRE(resp.ok);
+
+  auto arr = resp.result.as_arr();
+  DOCTEST_REQUIRE(arr.size() == 1);
+  auto obj = arr[0].as_obj();
+  DOCTEST_REQUIRE(obj["automation_id"].as_str() == "btn1");
+  DOCTEST_REQUIRE(obj["name"].as_str() == "Button 1");
+  DOCTEST_REQUIRE(obj["control_type"].as_str() == "50000");
+
+  auto rect = obj["bounding_rect"].as_obj();
+  DOCTEST_REQUIRE(rect["left"].as_num() == 10.0);
+}

--- a/tools/build_uia_check.sh
+++ b/tools/build_uia_check.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SRC_DIR}"
+
+if [[ -z "${CXX}" ]]; then
+  if command -v x86_64-w64-mingw32-g++ >/dev/null; then
+    CXX=x86_64-w64-mingw32-g++
+  elif command -v cl >/dev/null; then
+    # MSVC
+    cl check_uia.cpp /link ole32.lib oleaut32.lib uuid.lib
+    echo "Built check_uia.exe"
+    exit 0
+  else
+    echo "No suitable cross-compiler found (checked x86_64-w64-mingw32-g++ and cl)."
+    exit 1
+  fi
+fi
+
+echo "Compiling using ${CXX}..."
+"${CXX}" -o check_uia.exe check_uia.cpp -lole32 -loleaut32 -luuid
+echo "Built check_uia.exe"

--- a/tools/check_uia.cpp
+++ b/tools/check_uia.cpp
@@ -1,0 +1,45 @@
+#include <windows.h>
+#include <UIAutomation.h>
+#include <iostream>
+#include <string>
+
+int main() {
+    std::cout << "Initializing COM..." << std::endl;
+    HRESULT hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+    if (FAILED(hr)) {
+        std::cerr << "CoInitializeEx failed: " << std::hex << hr << std::endl;
+        return 1;
+    }
+
+    std::cout << "Creating IUIAutomation instance..." << std::endl;
+    IUIAutomation* pAutomation = NULL;
+    hr = CoCreateInstance(CLSID_CUIAutomation, NULL, CLSCTX_INPROC_SERVER, IID_IUIAutomation, (void**)&pAutomation);
+    if (FAILED(hr)) {
+        std::cerr << "CoCreateInstance CLSID_CUIAutomation failed: " << std::hex << hr << std::endl;
+        CoUninitialize();
+        return 1;
+    }
+
+    std::cout << "UIA initialized successfully." << std::endl;
+
+    std::cout << "Getting Root Element..." << std::endl;
+    IUIAutomationElement* pRoot = NULL;
+    hr = pAutomation->GetRootElement(&pRoot);
+    if (FAILED(hr) || !pRoot) {
+        std::cerr << "GetRootElement failed: " << std::hex << hr << std::endl;
+    } else {
+        std::cout << "Got Root Element." << std::endl;
+        // Try to get name?
+        BSTR bName = NULL;
+        if (SUCCEEDED(pRoot->get_CurrentName(&bName))) {
+             std::wcout << L"Root Name: " << (bName ? bName : L"") << std::endl;
+             SysFreeString(bName);
+        }
+        pRoot->Release();
+    }
+
+    pAutomation->Release();
+    CoUninitialize();
+    std::cout << "Done." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
This PR extends the functionality of WinInspect to support UI Automation (UIA) for inspecting elements beyond top-level windows. It also enhances the input injection system with robust helpers for mouse and keyboard events using `SendInput`, replacing raw input handling in the public API (though `send_input` remains available).

Key changes:
- `core/include/wininspect/types.hpp`: Added `UIElementInfo` struct.
- `core/include/wininspect/backend.hpp`: Added `inspect_ui_elements` and input helper methods to `IBackend`.
- `core/src/win32_backend.cpp`: Implemented UIA traversal and `SendInput` logic.
- `core/src/fake_backend.cpp`: Updated to mock new methods and record injected events for testing.
- `core/src/core.cpp`: Added RPC handlers for `ui.inspect`, `input.mouseClick`, `input.keyPress`, `input.text`.
- `tools/check_uia.cpp`: Added a standalone tool to verify UIA support in Wine/Windows environments.
- `CMakeLists.txt`: Added linking for COM libraries on Windows and registered the new test file.

Verification:
- Added `core/tests/test_uia.cpp` to verify `ui.inspect` logic against `FakeBackend`.
- Updated `core/tests/test_injection.cpp` to verify input helpers.
- Ran tests successfully (`ctest`).

---
*PR created automatically by Jules for task [14977114562491497045](https://jules.google.com/task/14977114562491497045) started by @mark-e-deyoung*