### PR TITLE
v0.3.0 Phase 2: Network security (IP allow/deny, per-IP rate limiting)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(wininspect_core
   core/src/crypto.cpp
   core/src/logger.cpp
   core/src/update.cpp
+  core/src/cidr.cpp
 )
 target_include_directories(wininspect_core PUBLIC
   core/include

--- a/core/include/wininspect/cidr.hpp
+++ b/core/include/wininspect/cidr.hpp
@@ -1,0 +1,38 @@
+#pragma once
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Mark E. DeYoung
+
+#include <string>
+#include <vector>
+#include <cstring>
+#include <cstdint>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#endif
+
+namespace wininspect {
+
+/// Parse a CIDR string like "192.168.1.0/24" or "::1/128" into a network
+/// address and prefix length. Returns true on success.
+bool parse_cidr(const std::string &cidr_str, struct sockaddr_storage &net,
+                int &prefix_len);
+
+/// Check if the given IP address matches a CIDR range.
+/// addr_str: "192.168.1.50" or "::1"
+/// cidr_str: "192.168.1.0/24" or "::1/128"
+bool cidr_match(const std::string &addr_str, const std::string &cidr_str);
+
+/// Check if an address matches any CIDR in a list.
+bool cidr_match_any(const std::string &addr_str,
+                    const std::vector<std::string> &cidr_list);
+
+/// Convert a sockaddr to a string for logging.
+std::string sockaddr_to_string(const struct sockaddr_storage &addr);
+
+} // namespace wininspect

--- a/core/src/cidr.cpp
+++ b/core/src/cidr.cpp
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Mark E. DeYoung
+
+#include "wininspect/cidr.hpp"
+#include <algorithm>
+#include <sstream>
+
+namespace wininspect {
+
+bool parse_cidr(const std::string &cidr_str, struct sockaddr_storage &net,
+                int &prefix_len) {
+  std::memset(&net, 0, sizeof(net));
+
+  // Split on '/'
+  auto slash = cidr_str.find('/');
+  if (slash == std::string::npos) return false;
+
+  std::string addr_part = cidr_str.substr(0, slash);
+  std::string prefix_part = cidr_str.substr(slash + 1);
+
+  prefix_len = std::stoi(prefix_part);
+  if (prefix_len < 0) return false;
+
+  // Try IPv4 first
+  struct sockaddr_in *sin = (struct sockaddr_in *)&net;
+  if (inet_pton(AF_INET, addr_part.c_str(), &sin->sin_addr) == 1) {
+    sin->sin_family = AF_INET;
+    if (prefix_len > 32) return false;
+    return true;
+  }
+
+  // Try IPv6
+  struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&net;
+  if (inet_pton(AF_INET6, addr_part.c_str(), &sin6->sin6_addr) == 1) {
+    sin6->sin6_family = AF_INET6;
+    if (prefix_len > 128) return false;
+    return true;
+  }
+
+  return false;
+}
+
+bool cidr_match(const std::string &addr_str, const std::string &cidr_str) {
+  struct sockaddr_storage net;
+  int prefix_len = 0;
+  if (!parse_cidr(cidr_str, net, prefix_len)) return false;
+
+  // Parse the address to check
+  struct sockaddr_storage addr;
+  std::memset(&addr, 0, sizeof(addr));
+
+  struct sockaddr_in *addr_in = (struct sockaddr_in *)&addr;
+  struct sockaddr_in6 *addr_in6 = (struct sockaddr_in6 *)&addr;
+
+  if (net.ss_family == AF_INET) {
+    if (inet_pton(AF_INET, addr_str.c_str(), &addr_in->sin_addr) != 1)
+      return false;
+    addr_in->sin_family = AF_INET;
+
+    uint32_t net_addr = ntohl(((struct sockaddr_in *)&net)->sin_addr.s_addr);
+    uint32_t test_addr = ntohl(addr_in->sin_addr.s_addr);
+    uint32_t mask = (prefix_len == 0) ? 0 : (uint32_t)(~0ULL << (32 - prefix_len));
+
+    return (net_addr & mask) == (test_addr & mask);
+  }
+
+  if (net.ss_family == AF_INET6) {
+    if (inet_pton(AF_INET6, addr_str.c_str(), &addr_in6->sin6_addr) != 1)
+      return false;
+    addr_in6->sin6_family = AF_INET6;
+
+    // Compare 128-bit addresses, prefix_len bits at a time
+    auto *net_bytes = (const uint8_t *)&(((struct sockaddr_in6 *)&net)->sin6_addr);
+    auto *test_bytes = (const uint8_t *)&addr_in6->sin6_addr;
+
+    int full_bytes = prefix_len / 8;
+    int remaining_bits = prefix_len % 8;
+
+    for (int i = 0; i < full_bytes; i++) {
+      if (net_bytes[i] != test_bytes[i]) return false;
+    }
+
+    if (remaining_bits > 0) {
+      uint8_t mask = (uint8_t)(0xFF << (8 - remaining_bits));
+      if ((net_bytes[full_bytes] & mask) != (test_bytes[full_bytes] & mask))
+        return false;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+bool cidr_match_any(const std::string &addr_str,
+                    const std::vector<std::string> &cidr_list) {
+  for (auto &cidr : cidr_list) {
+    if (cidr_match(addr_str, cidr)) return true;
+  }
+  return false;
+}
+
+std::string sockaddr_to_string(const struct sockaddr_storage &addr) {
+  char buf[64] = {};
+  if (addr.ss_family == AF_INET) {
+    auto *sin = (const struct sockaddr_in *)&addr;
+    inet_ntop(AF_INET, &sin->sin_addr, buf, sizeof(buf));
+  } else if (addr.ss_family == AF_INET6) {
+    auto *sin6 = (const struct sockaddr_in6 *)&addr;
+    inet_ntop(AF_INET6, &sin6->sin6_addr, buf, sizeof(buf));
+  }
+  return std::string(buf);
+}
+
+} // namespace wininspect

--- a/daemon/src/server.cpp
+++ b/daemon/src/server.cpp
@@ -214,9 +214,10 @@ int main(int argc, char **argv) {
   bool include_hostname = false;
   bool admin_logs = false;
   bool no_clipboard = false;
-  int rate_limit_ms = 0;
+  int per_ip_rate_limit_ms = 0;
   std::string auth_keys;
   std::string allow_str, deny_str;
+  std::vector<std::string> allow_cidrs, deny_cidrs;
   bool require_auth = false;
   int tcp_port = 1985;
   int max_snaps = 1000;
@@ -255,6 +256,27 @@ int main(int argc, char **argv) {
     }
     if (std::string(argv[i]) == "--port" && i + 1 < argc) {
       tcp_port = std::stoi(argv[++i]);
+    }
+    if (std::string(argv[i]) == "--rate-limit-ms" && i + 1 < argc) {
+      per_ip_rate_limit_ms = std::stoi(argv[++i]);
+    }
+    if (std::string(argv[i]) == "--allow-ips" && i + 1 < argc) {
+      std::string list = argv[++i];
+      size_t pos = 0;
+      while ((pos = list.find(",")) != std::string::npos) {
+        allow_cidrs.push_back(list.substr(0, pos));
+        list.erase(0, pos + 1);
+      }
+      if (!list.empty()) allow_cidrs.push_back(list);
+    }
+    if (std::string(argv[i]) == "--deny-ips" && i + 1 < argc) {
+      std::string list = argv[++i];
+      size_t pos = 0;
+      while ((pos = list.find(",")) != std::string::npos) {
+        deny_cidrs.push_back(list.substr(0, pos));
+        list.erase(0, pos + 1);
+      }
+      if (!list.empty()) deny_cidrs.push_back(list);
     }
     if (std::string(argv[i]) == "--max-snapshots" && i + 1 < argc) {
       max_snaps = std::stoi(argv[++i]);
@@ -312,7 +334,9 @@ int main(int argc, char **argv) {
   st->poll_interval_ms = poll_interval;
   st->max_wait_ms = max_wait;
   st->discovery_port = discovery_port;
-  st->rate_limit_ms = rate_limit_ms;
+  st->per_ip_rate_limit_ms = per_ip_rate_limit_ms;
+  st->allow_cidrs = allow_cidrs;
+  st->deny_cidrs = deny_cidrs;
 
   // Parse method authorization lists
   if (!allow_str.empty()) {
@@ -402,7 +426,7 @@ int main(int argc, char **argv) {
       // Create a background thread for TCP if tray is running
       std::thread([&, tcp, bind_public, read_only]() {
         try {
-          tcp->start(&running, bind_public, auth_keys_data, read_only, admin_logs, no_clipboard, rate_limit_ms);
+          tcp->start(&running, bind_public, auth_keys_data, read_only, admin_logs, no_clipboard, 0);
         } catch (...) {}
       }).detach();
       tray.run();
@@ -410,7 +434,7 @@ int main(int argc, char **argv) {
   }
 
   try {
-    tcp->start(&running, bind_public, auth_keys_data, read_only, admin_logs, no_clipboard, rate_limit_ms);
+    tcp->start(&running, bind_public, auth_keys_data, read_only, admin_logs, no_clipboard, 0);
   } catch (...) {
     LOG_ERROR("TCP Server fatal error.");
   }

--- a/daemon/src/server_state.hpp
+++ b/daemon/src/server_state.hpp
@@ -60,6 +60,15 @@ struct ServerState {
   // Method authorization sets
   std::set<std::string> allow_methods;  // empty = all allowed
   std::set<std::string> deny_methods;   // empty = none denied
+
+  // IP access control (CIDR notation)
+  std::vector<std::string> allow_cidrs;  // empty = all allowed
+  std::vector<std::string> deny_cidrs;   // empty = none denied
+
+  // Per-IP rate limiting (key = IP string)
+  int per_ip_rate_limit_ms = 0;
+  std::map<std::string, std::chrono::steady_clock::time_point> last_accept_per_ip;
+  std::mutex ip_rate_mu;
 };
 
 struct ClientSession {

--- a/daemon/src/tcp_server.cpp
+++ b/daemon/src/tcp_server.cpp
@@ -1,4 +1,5 @@
 #include "wininspect/base64.hpp"
+#include "wininspect/cidr.hpp"
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Mark E. DeYoung
 
@@ -501,7 +502,10 @@ void TcpServer::start(std::atomic<bool> *running, bool bind_public,
   ioctlsocket(listen_sock, FIONBIO, &mode);
 
   while (running->load()) {
-    SOCKET client = accept(listen_sock, nullptr, nullptr);
+    struct sockaddr_storage client_addr;
+    socklen_t client_addr_len = sizeof(client_addr);
+    SOCKET client = accept(listen_sock, (struct sockaddr *)&client_addr,
+                           &client_addr_len);
     if (client == INVALID_SOCKET) {
       if (WSAGetLastError() == WSAEWOULDBLOCK) {
         Sleep(100);
@@ -513,16 +517,49 @@ void TcpServer::start(std::atomic<bool> *running, bool bind_public,
     u_long m2 = 0;
     ioctlsocket(client, FIONBIO, &m2);
 
-    // Rate limiting: reject connections arriving within rate_limit_ms
-    if (rate_limit_ms > 0) {
-      auto now = std::chrono::steady_clock::now();
-      auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-          now - state_->last_accept_time).count();
-      if (elapsed < rate_limit_ms) {
+    // Get client IP string for logging and access control
+    std::string client_ip = sockaddr_to_string(client_addr);
+
+    // Deny list check (checked first — explicit deny takes priority)
+    if (!state_->deny_cidrs.empty()) {
+      if (cidr_match_any(client_ip, state_->deny_cidrs)) {
+        LOG_DEBUG("Rejected connection from denied IP: " + client_ip);
         closesocket(client);
         continue;
       }
-      state_->last_accept_time = now;
+    }
+
+    // Allow list check (if non-empty, only matching IPs are accepted)
+    if (!state_->allow_cidrs.empty()) {
+      if (!cidr_match_any(client_ip, state_->allow_cidrs)) {
+        LOG_DEBUG("Rejected connection from non-allowed IP: " + client_ip);
+        closesocket(client);
+        continue;
+      }
+    }
+
+    // Per-IP rate limiting
+    if (state_->per_ip_rate_limit_ms > 0) {
+      auto now = std::chrono::steady_clock::now();
+      bool too_fast = false;
+      {
+        std::lock_guard<std::mutex> lk(state_->ip_rate_mu);
+        auto it = state_->last_accept_per_ip.find(client_ip);
+        if (it != state_->last_accept_per_ip.end()) {
+          auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+              now - it->second).count();
+          if (elapsed < state_->per_ip_rate_limit_ms) {
+            too_fast = true;
+          }
+        }
+        // Always update timestamp to prevent rapid retry flood
+        state_->last_accept_per_ip[client_ip] = now;
+      }
+      if (too_fast) {
+        LOG_DEBUG("Rate limited connection from " + client_ip);
+        closesocket(client);
+        continue;
+      }
     }
 
     {


### PR DESCRIPTION
## Summary
Adds IP-based access control and per-source-IP rate limiting to the TCP server.

Closes #54.

## Changes
- **CIDR matching** (`core/src/cidr.cpp`) — Parse and match IPv4/IPv6 CIDR
  notation. Supports `192.168.1.0/24`, `10.0.0.0/8`, `::1/128`, etc.
- **IP allow/deny lists** — `--allow-ips 192.168.1.0/24,10.0.0.0/8` and
  `--deny-ips <cidrs>`. Deny checked first, then allow. Empty allow = allow all.
- **Per-IP rate limiting** — `--rate-limit-ms <n>` now tracks per source IP
  instead of globally. One fast client no longer starves others.

## Testing
- ✅ Builds clean on MinGW 16.1.0
- ✅ All 3 test suites pass
- ✅ Smoke: daemon with `--allow-ips 127.0.0.0/8 --deny-ips 10.0.0.0/8`
  accepts localhost connections